### PR TITLE
fix a memory leak

### DIFF
--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -1309,6 +1309,7 @@ QuicConnGetSourceCidFromSeq(
                     QuicBindingRemoveSourceConnectionID(
                         CID->Binding,
                         CID);
+                    CXPLAT_FREE(CID, QUIC_POOL_CIDHASH);
                 }
                 QuicTraceEvent(
                     ConnSourceCidRemoved,


### PR DESCRIPTION
## Description

This pull request introduces a small but important memory management improvement to the QUIC connection code. Specifically, it ensures that source connection IDs are properly freed after removal, helping to prevent memory leaks.

* Memory management:
  * In `src/core/connection.h`, after removing a source connection ID with `QuicBindingRemoveSourceConnectionID`, the code now explicitly frees the associated memory using `CXPLAT_FREE` to prevent memory leaks.

## Testing

No

## Documentation

No