### PR TITLE
Change target branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
+    - seera-main
     - release/*
   pull_request:
     branches:
-    - main
+    - seera-main
     - release/*
 
 concurrency:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
+    - seera-main
     - release/*
   pull_request:
     branches:
-    - main
+    - seera-main
     - release/*
 
 permissions:

--- a/.github/workflows/check-clog.yml
+++ b/.github/workflows/check-clog.yml
@@ -3,7 +3,7 @@ name: CLOG
 on:
   push:
     branches:
-    - main
+    - seera-main
     - release/*
   pull_request:
     branches:

--- a/.github/workflows/check-dotnet.yml
+++ b/.github/workflows/check-dotnet.yml
@@ -3,11 +3,11 @@ name: CheckDotnet
 on:
   push:
     branches:
-    - main
+    - seera-main
     - release/*
   pull_request:
     branches:
-    - main
+    - seera-main
     - release/*
 
 permissions: read-all

--- a/.github/workflows/docker-publish-xcomp.yml
+++ b/.github/workflows/docker-publish-xcomp.yml
@@ -8,7 +8,7 @@ on:
     - .docker/ubuntu-22.04/*
     - .docker/ubuntu-24.04/*
   pull_request:
-    branches: [ seeramain ]
+    branches: [ seera-main ]
     paths:
     - .github/workflows/docker-publish-xcomp.yml
     - .docker/ubuntu-22.04/*

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
+    - seera-main
     - release/*
   pull_request:
     branches:


### PR DESCRIPTION
## Description

This pull request updates the GitHub Actions workflow triggers to use the `seera-main` branch instead of `main`. This ensures that CI/CD workflows are executed on the correct primary branch for this repository, and also fixes a typo in one workflow trigger.

Branch trigger updates:

* Updated all workflow YAML files (`build.yml`, `cargo.yml`, `check-clog.yml`, `check-dotnet.yml`, `package-linux.yml`) to trigger on `seera-main` instead of `main` for both `push` and `pull_request` events. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L7-R11) [[2]](diffhunk://#diff-c405e4afd304c7295273c10a937f4a1e3d7853ff71b4066c487e1f3c8291b690L7-R11) [[3]](diffhunk://#diff-a643f4a2baa74579c581c45a771d9944001d4874694bdc576372a2b86f3e2025L6-R6) [[4]](diffhunk://#diff-4085e93983f776ab1b1a238f4e09c62cd5023881f6fdf19fe4c9cef8f2e6e11aL6-R10) [[5]](diffhunk://#diff-3308cfa2893e0ead396ea915e0d675e557d1bd273f9abab1eaec967c57768644L7-R7)

Typo fix:

* Fixed a typo in the `docker-publish-xcomp.yml` workflow by changing the branch trigger from `seeramain` to `seera-main`.
* 
## Testing

No

## Documentation

No