### PR TITLE
Setup .NET 10 SDK and delete macos-latest-xlarge

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-latest-xlarge]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         vec: [
           { tls: "quictls", features: "" },
           { tls: "quictls", features: "--features static" },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,7 +186,7 @@ jobs:
       if: matrix.vec.plat == 'linux' || matrix.vec.plat == 'macos'
       run: |
         sudo chmod -R 777 artifacts
-    - name Setup .NET 10 SDK
+    - name: Setup .NET 10 SDK
       if: matrix.vec.plat == 'linux' || matrix.vec.plat == 'macos'
       uses: actions/setup-dotnet@v4
       with:


### PR DESCRIPTION
## Description

This pull request makes minor adjustments to the CI workflows, specifically by updating the OS matrix for the Cargo workflow and adding a step to set up the .NET 10 SDK in the test workflow.

CI Workflow Updates:

* Removed `macos-latest-xlarge` from the OS matrix in `.github/workflows/cargo.yml`, so jobs will now only run on `ubuntu-latest`, `windows-latest`, and `macos-latest`.
* Added a step to set up the .NET 10 SDK (`dotnet-version: '10.0.101'`) for Linux and macOS platforms in `.github/workflows/test.yml`.

## Testing

No

## Documentation

No
