### PR TITLE
 Updates the package metadata in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "msquic"
+name = "seera-msquic"
 version = "2.6.0-beta"
 edition = "2021"
-authors = ["Microsoft"]
-description = "Microsoft implementation of the IETF QUIC protocol"
+authors = ["Microsoft", "SEERA-Networks"]
+description = "SEERA-Networks fork of Microsoft implementation of the IETF QUIC protocol"
 readme = "README.md"
-repository = "https://github.com/microsoft/msquic/"
+repository = "https://github.com/seera-networks/msquic/"
 license = "MIT"
 categories = ["network-programming", "asynchronous"]
 keywords = ["quic", "network", "secure"]


### PR DESCRIPTION
## Description
This pull request updates the package metadata in `Cargo.toml` to reflect the transition from the original Microsoft repository to the SEERA-Networks fork. The changes clarify authorship, description, and repository information to accurately represent the new project ownership.

Metadata and ownership updates:

* Renamed the package from `msquic` to `seera-msquic` to indicate the forked project.
* Updated the `authors` field to include "SEERA-Networks" alongside "Microsoft".
* Changed the `description` to specify this is the SEERA-Networks fork of the Microsoft implementation.
* Updated the `repository` URL to point to the SEERA-Networks GitHub repository.

## Testing

No

## Documentation

No