### PR TITLE
Remove support for Windows Server Prerelease

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -80,7 +80,7 @@ jobs:
         name: BVT-${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.xdp }}${{ matrix.vec.qtip }}${{ matrix.vec.systemcrypto }}${{ matrix.vec.sanitize }}
         path: artifacts/coverage/*.cov
 
-  stress-win2025:
+  stress-win2022:
     name: Stress Win2022
     needs: [build-windows]
     strategy:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -39,8 +39,8 @@ jobs:
       build: ${{ matrix.vec.build }}
       repo: ${{ github.repository }}
 
-  bvt-winlatest:
-    name: BVT WinPrerelease
+  bvt-win2022:
+    name: BVT Win2022
     needs: [build-windows]
     strategy:
       fail-fast: false
@@ -49,10 +49,7 @@ jobs:
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", build: "-Test", xdp: "-UseXdp" },
         ]
-    runs-on:
-     - self-hosted
-     - "1ES.Pool=1es-msquic-pool"
-     - "1ES.ImageOverride=WinServerPrerelease-LatestPwsh"
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
       with:
@@ -83,8 +80,8 @@ jobs:
         name: BVT-${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.xdp }}${{ matrix.vec.qtip }}${{ matrix.vec.systemcrypto }}${{ matrix.vec.sanitize }}
         path: artifacts/coverage/*.cov
 
-  stress-winlatest:
-    name: Stress WinPrerelease
+  stress-win2025:
+    name: Stress Win2022
     needs: [build-windows]
     strategy:
       fail-fast: false
@@ -92,10 +89,7 @@ jobs:
         vec: [
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", build: "-Test" },
         ]
-    runs-on:
-    - self-hosted
-    - "1ES.Pool=1es-msquic-pool"
-    - "1ES.ImageOverride=WinServerPrerelease-LatestPwsh"
+    runs-on: windows-2022
     env:
       main-timeout: 3600000
       main-repeat: 100
@@ -133,8 +127,8 @@ jobs:
         name: Spin-${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.xdp }}${{ matrix.vec.sanitize }}
         path: artifacts/coverage/*.cov
 
-  recvfuzz-winlatest:
-    name: Recv Fuzz WinPrerelease
+  recvfuzz-win2022:
+    name: Recv Fuzz Win2022
     needs: [build-windows]
     strategy:
       fail-fast: false
@@ -142,10 +136,7 @@ jobs:
         vec: [
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", build: "-Test" },
         ]
-    runs-on:
-    - self-hosted
-    - "1ES.Pool=1es-msquic-pool"
-    - "1ES.ImageOverride=WinServerPrerelease-LatestPwsh"
+    runs-on: windows-2022
     env:
       main-timeout: 3600000
       pr-timeout: 600000
@@ -181,7 +172,7 @@ jobs:
 
   merge-coverage:
     name: Merge Coverage
-    needs: [bvt-winlatest, stress-winlatest, recvfuzz-winlatest]
+    needs: [bvt-win2022, stress-win2022, recvfuzz-win2022]
     runs-on: windows-2022
     steps:
     - name: Checkout repository

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -111,7 +111,6 @@ jobs:
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", xdp: "-UseXdp", sanitize: "-SanitizeAddress", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", xdp: "-UseXdp", build: "-Test" },
-          { config: "Debug", plat: "windows", os: "WinServerPrerelease", arch: "x64", tls: "schannel", build: "-Test" },
         ]
     runs-on: ${{ matrix.vec.plat == 'windows' && matrix.vec.os == 'WinServerPrerelease' && fromJson('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=WinServerPrerelease-LatestPwsh'']') || matrix.vec.os }}
     env:
@@ -175,7 +174,6 @@ jobs:
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "quictls", xdp: "-UseXdp", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl", build: "-Test" },
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "openssl", xdp: "-UseXdp", build: "-Test" },
-          { config: "Debug", plat: "windows", os: "WinServerPrerelease", arch: "x64", tls: "schannel", build: "-Test" },
         ]
     runs-on: ${{ matrix.vec.plat == 'windows' && matrix.vec.os == 'WinServerPrerelease' && fromJson('[''self-hosted'', ''1ES.Pool=1es-msquic-pool'', ''1ES.ImageOverride=WinServerPrerelease-LatestPwsh'']') || matrix.vec.os }}
     env:


### PR DESCRIPTION
## Description

This pull request updates the CI workflows to remove support for Windows Server Prerelease test jobs and standardize on Windows Server 2022 for all related Windows test jobs. The changes simplify the job definitions and ensure consistency across the code coverage and stress test workflows.

**Workflow updates to use Windows Server 2022:**

* Renamed job identifiers and display names from `*-winlatest` or `*-WinPrerelease` to `*-win2022` and updated their `runs-on` settings to use `windows-2022` instead of self-hosted Windows Server Prerelease runners in `.github/workflows/code-coverage.yml`. [[1]](diffhunk://#diff-49708f979e226a1e7bd7a68d71b2e91aae8114dd3e9254d9830cd3b4d62d4303L42-R43) [[2]](diffhunk://#diff-49708f979e226a1e7bd7a68d71b2e91aae8114dd3e9254d9830cd3b4d62d4303L52-R52) [[3]](diffhunk://#diff-49708f979e226a1e7bd7a68d71b2e91aae8114dd3e9254d9830cd3b4d62d4303L86-R92) [[4]](diffhunk://#diff-49708f979e226a1e7bd7a68d71b2e91aae8114dd3e9254d9830cd3b4d62d4303L136-R139)
* Updated dependencies in the `merge-coverage` job to reference the new Windows Server 2022 job names in `.github/workflows/code-coverage.yml`.

**Removal of obsolete Windows Server Prerelease test matrix entries:**

* Removed all test matrix entries for `WinServerPrerelease` from the job definitions in `.github/workflows/stress.yml`. [[1]](diffhunk://#diff-6dcb0e7465f70dfff25e0222278051e395b56d0b082ba35722525f92338b47caL114) [[2]](diffhunk://#diff-6dcb0e7465f70dfff25e0222278051e395b56d0b082ba35722525f92338b47caL178)
## Testing

_Do any existing tests cover this change? Are new tests needed?_

No

_Is there any documentation impact for this change?_

No