### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,20 @@
 [![](https://img.shields.io/static/v1?label=RFC&message=9369&color=brightgreen)](https://tools.ietf.org/html/rfc9369)
 [![](https://img.shields.io/static/v1?label=Draft&message=Load%20Balancers&color=blue)](https://tools.ietf.org/html/draft-ietf-quic-load-balancers)
 [![](https://img.shields.io/static/v1?label=Draft&message=ACK%20Frequency&color=blue)](https://tools.ietf.org/html/draft-ietf-quic-ack-frequency)
+[![](https://img.shields.io/static/v1?label=Draft&message=ReliableReset&color=blue)](https://tools.ietf.org/html/draft-ietf-quic-reliable-stream-reset/)
+[![](https://img.shields.io/static/v1?label=Draft&message=AddressDiscovery&color=blue)](https://tools.ietf.org/html/draft-ietf-quic-address-discovery/)
 [![](https://img.shields.io/static/v1?label=Draft&message=Disable%20Encryption&color=blueviolet)](https://tools.ietf.org/html/draft-banks-quic-disable-encryption)
 [![](https://img.shields.io/static/v1?label=Draft&message=Performance&color=blueviolet)](https://tools.ietf.org/html/draft-banks-quic-performance)
 [![](https://img.shields.io/static/v1?label=Draft&message=CIBIR&color=blueviolet)](https://tools.ietf.org/html/draft-banks-quic-cibir)
 [![](https://img.shields.io/static/v1?label=Draft&message=Timestamps&color=blueviolet)](https://tools.ietf.org/html/draft-huitema-quic-ts)
-[![](https://img.shields.io/static/v1?label=Draft&message=ReliableReset&color=blueviolet)](https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/)
+[![](https://img.shields.io/static/v1?label=Draft&message=ServerMigration&color=blueviolet)](https://datatracker.ietf.org/doc/html/draft-kozuka-quic-server-migration/)
+[![](https://img.shields.io/static/v1?label=Draft&message=NAT-Traversal&color=blueviolet)](https://datatracker.ietf.org/doc/html/draft-seemann-quic-nat-traversal/)
+
 
 ## Main differences to upstream MsQuic
 
 - Client Initiated Migration
-<!-- - Implements additional QUIC extensions
+- Implements additional QUIC extensions
+  - Address Discovery
+  - Server Initiated Migration
   - NAT-T
-  - Server Initiated Migration -->


### PR DESCRIPTION
## Description

This pull request updates the `README.md` to reflect support for new QUIC protocol drafts and extensions. The main changes involve adding badges for new drafts and updating the list of implemented QUIC extensions to provide more detail.

**Documentation updates:**

* Added badges for the `ReliableReset` and `AddressDiscovery` QUIC drafts, and for `ServerMigration` and `NAT-Traversal` drafts, improving visibility of supported protocols.

* Updated the "Main differences to upstream MsQuic" section to explicitly list `Address Discovery`, `Server Initiated Migration`, and `NAT-T` as implemented QUIC extensions, making the documentation more accurate and informative.

## Testing

No

## Documentation

No
