### PR TITLE
Remove *.md except for README.md from crate package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 keywords = ["quic", "network", "secure"]
 build = "scripts/build.rs"
 include = [
-    "*/*.md",
+    "/README.md",
     "/*.toml",
     "/cmake",
     "/CMakeLists.txt",


### PR DESCRIPTION
## Description

Remove *.md except for README.md from crate package to make sure that  crate size doesn't exceed 10MB.

## Testing

No

## Documentation

No