### PR TITLE
Fix OBSERVED_ADDRESS frame codepoints and make address discovery opt-in

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -70,6 +70,8 @@ The following settings are available via registry as well as via [QUIC_SETTINGS]
 | Server Initiated Migration         | uint8_t    | ServerMigrationEnabled      |         0 (FALSE) | Enable Server Initiated Migration. |
 | ADD_ADDRESS handling mode          | uint8_t    | AddAddressMode              |         0 (AUTO)  | Control handling of ADD_ADDRESS Frame |
 | IgnoreUnreachable                  | uint8_t    | IgnoreUnreachable           |         0 (FALSE) | Ignore Unreachable during the Handshake |
+| SendObservedAddressReports         | uint8_t    | SendObservedAddressReports  |         0 (FALSE) | Report the peer's observed address to it via OBSERVED_ADDRESS frames. Frames are only sent if the peer also asked to receive them. |
+| ReceiveObservedAddressReports      | uint8_t    | ReceiveObservedAddressReports |       0 (FALSE) | Ask the peer to report this endpoint's observed address. Reports arrive as `QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS`. |
 
 The types map to registry types as follows:
   - `uint64_t` is a `REG_QWORD`.

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -2110,8 +2110,22 @@ QuicConnGenerateLocalTransportParameters(
         QUIC_TP_FLAG_MAX_ACK_DELAY |
         QUIC_TP_FLAG_MIN_ACK_DELAY |
         QUIC_TP_FLAG_ACTIVE_CONNECTION_ID_LIMIT |
-        QUIC_TP_FLAG_OBSERVED_ADDRESS |
         QUIC_TP_FLAG_NAT_TRAVERSE;
+
+    //
+    // The observed_address transport parameter is only sent when at least one
+    // direction of the extension is enabled; its value states which.
+    //
+    if (Connection->Settings.SendObservedAddressReports ||
+        Connection->Settings.ReceiveObservedAddressReports) {
+        LocalTP->Flags |= QUIC_TP_FLAG_OBSERVED_ADDRESS;
+        LocalTP->ObservedAddressRole =
+            Connection->Settings.SendObservedAddressReports ?
+                (Connection->Settings.ReceiveObservedAddressReports ?
+                    QUIC_TP_OBSERVED_ADDRESS_ROLE_BOTH :
+                    QUIC_TP_OBSERVED_ADDRESS_ROLE_SEND_ONLY) :
+                QUIC_TP_OBSERVED_ADDRESS_ROLE_RECEIVE_ONLY;
+    }
 
     if (Connection->Settings.IdleTimeoutMs != 0) {
         LocalTP->Flags |= QUIC_TP_FLAG_IDLE_TIMEOUT;
@@ -2769,7 +2783,7 @@ QuicConnProcessPeerTransportParameters(
             UINT32_MAX);
     }
 
-    if (Connection->PeerTransportParams.Flags & QUIC_TP_FLAG_OBSERVED_ADDRESS) {
+    if (QuicConnPeerWantsObservedAddressReports(Connection)) {
         Connection->State.ObservedAddressNegotiated = TRUE;
         QuicSendSetSendFlag(
             &Connection->Send,
@@ -5533,7 +5547,21 @@ QuicConnRecvFrames(
         }
 
         case QUIC_FRAME_OBSERVED_ADDRESS_V4:
-        case QUIC_FRAME_OBSERVED_ADDRESS_V6: { // Always accept the frame, because we always enable support.
+        case QUIC_FRAME_OBSERVED_ADDRESS_V6: {
+            if (!Connection->Settings.ReceiveObservedAddressReports) {
+                //
+                // We never asked to receive these reports, so the peer isn't
+                // allowed to send them.
+                //
+                QuicTraceEvent(
+                    ConnError,
+                    "[conn][%p] ERROR, %s.",
+                    Connection,
+                    "Received OBSERVED_ADDRESS frame when not negotiated");
+                QuicConnTransportError(Connection, QUIC_ERROR_PROTOCOL_VIOLATION);
+                return FALSE;
+            }
+
             QUIC_OBSERVED_ADDRESS_EX Frame;
             if (!QuicObservedAddressFrameDecode(FrameType, PayloadLength, Payload, &Offset, &Frame)) {
                 QuicTraceEvent(
@@ -9542,7 +9570,7 @@ QuicConnApplyNewSettings(
             QuicConnIndicateEvent(Connection, &Event);
         }
 
-        if (QuicConnIsServer(Connection) && Connection->PeerTransportParams.Flags & QUIC_TP_FLAG_OBSERVED_ADDRESS) {
+        if (QuicConnIsServer(Connection) && QuicConnPeerWantsObservedAddressReports(Connection)) {
             Connection->State.ObservedAddressNegotiated = TRUE;
             QuicSendSetSendFlag(
                 &Connection->Send,

--- a/src/core/connection.h
+++ b/src/core/connection.h
@@ -793,6 +793,23 @@ QuicConnIsServer(
 }
 
 //
+// Helper to determine if observed address reports should be sent to the peer:
+// this endpoint must be willing to send them, and the peer must have asked to
+// receive them.
+//
+QUIC_INLINE
+BOOLEAN
+QuicConnPeerWantsObservedAddressReports(
+    _In_ const QUIC_CONNECTION * const Connection
+    )
+{
+    return
+        Connection->Settings.SendObservedAddressReports &&
+        (Connection->PeerTransportParams.Flags & QUIC_TP_FLAG_OBSERVED_ADDRESS) &&
+        QUIC_TP_OBSERVED_ADDRESS_ROLE_RECEIVES(Connection->PeerTransportParams.ObservedAddressRole);
+}
+
+//
 // Helper to determine if a connection is client side.
 //
 QUIC_INLINE

--- a/src/core/crypto_tls.c
+++ b/src/core/crypto_tls.c
@@ -912,7 +912,7 @@ QuicCryptoTlsEncodeTransportParameters(
         RequiredTPLen +=
             TlsTransportParamLength(
                 QUIC_TP_ID_OBSERVED_ADDRESS,
-                QuicVarIntSize(2)); // Hardcode for now
+                QuicVarIntSize(TransportParams->ObservedAddressRole));
     }
     if (TransportParams->Flags & QUIC_TP_FLAG_NAT_TRAVERSE) {
         if (IsServerTP) {
@@ -1285,13 +1285,13 @@ QuicCryptoTlsEncodeTransportParameters(
         TPBuf =
             TlsWriteTransportParamVarInt(
                 QUIC_TP_ID_OBSERVED_ADDRESS,
-                2,
+                TransportParams->ObservedAddressRole,
                 TPBuf);
         QuicTraceLogConnVerbose(
             EncodeTPObservedAddress,
             Connection,
             "TP: Observed Address (%u)",
-            2);
+            (uint32_t)TransportParams->ObservedAddressRole);
     }
     if (TransportParams->Flags & QUIC_TP_FLAG_NAT_TRAVERSE) {
         if (IsServerTP) {
@@ -2095,7 +2095,7 @@ QuicCryptoTlsDecodeTransportParameters( // NOLINT(readability-function-size, goo
                     "Invalid length of QUIC_TP_ID_OBSERVED_ADDRESS");
                 goto Exit;
             }
-            if (value > 2) {
+            if (value > QUIC_TP_OBSERVED_ADDRESS_ROLE_BOTH) {
                 QuicTraceEvent(
                     ConnError,
                     "[conn][%p] ERROR, %s.",
@@ -2108,7 +2108,8 @@ QuicCryptoTlsDecodeTransportParameters( // NOLINT(readability-function-size, goo
                 Connection,
                 "TP: Observed Address (%u)",
                 (uint32_t)value);
-            TransportParams->Flags |= QUIC_TP_FLAG_OBSERVED_ADDRESS; // TODO - Pass value?
+            TransportParams->Flags |= QUIC_TP_FLAG_OBSERVED_ADDRESS;
+            TransportParams->ObservedAddressRole = value;
             break;
         }
 

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -159,9 +159,9 @@ typedef enum QUIC_FRAME_TYPE {
     QUIC_FRAME_IMMEDIATE_ACK        = 0x1fULL,
     /* 0xaf to 0x2f4 are unused currently */
     QUIC_FRAME_TIMESTAMP            = 0x2f5ULL,
-    /* 0x2f6 to 0x9f80 are unused currently */
-    QUIC_FRAME_OBSERVED_ADDRESS_V4  = 0x9f81ULL, // 0x9f81a6ULL,
-    QUIC_FRAME_OBSERVED_ADDRESS_V6  = 0x9f82ULL, // 0x9f81a7ULL,
+    /* 0x2f6 to 0x9f81a5 are unused currently */
+    QUIC_FRAME_OBSERVED_ADDRESS_V4  = 0x9f81a6ULL,
+    QUIC_FRAME_OBSERVED_ADDRESS_V6  = 0x9f81a7ULL,
 
     QUIC_FRAME_ADD_ADDRESS_V4       = 0x3d7e90LL,
     QUIC_FRAME_ADD_ADDRESS_V6       = 0x3d7e91LL,

--- a/src/core/quicdef.h
+++ b/src/core/quicdef.h
@@ -621,6 +621,13 @@ CXPLAT_STATIC_ASSERT(
 #define QUIC_DEFAULT_MULTIPATH_ENABLED               FALSE
 
 //
+// The default settings for the address discovery extension. Both directions
+// are off by default; the app opts in per direction.
+//
+#define QUIC_DEFAULT_SEND_OBSERVED_ADDRESS_REPORTS      FALSE
+#define QUIC_DEFAULT_RECEIVE_OBSERVED_ADDRESS_REPORTS   FALSE
+
+//
 // The number of rounds in Cubic Slow Start to sample RTT.
 //
 #define QUIC_HYSTART_DEFAULT_N_SAMPLING             8
@@ -709,6 +716,21 @@ CXPLAT_STATIC_ASSERT(
 //
 #define QUIC_TP_MAX_PATH_ID_MAX                             ((1ULL << 32) - 1)
 
+//
+// Values of the observed_address transport parameter, per
+// draft-ietf-quic-address-discovery. The value states which directions of the
+// extension the endpoint is willing to take part in.
+//
+#define QUIC_TP_OBSERVED_ADDRESS_ROLE_SEND_ONLY             0
+#define QUIC_TP_OBSERVED_ADDRESS_ROLE_RECEIVE_ONLY          1
+#define QUIC_TP_OBSERVED_ADDRESS_ROLE_BOTH                  2
+
+#define QUIC_TP_OBSERVED_ADDRESS_ROLE_SENDS(Role) \
+    ((Role) == QUIC_TP_OBSERVED_ADDRESS_ROLE_SEND_ONLY || (Role) == QUIC_TP_OBSERVED_ADDRESS_ROLE_BOTH)
+
+#define QUIC_TP_OBSERVED_ADDRESS_ROLE_RECEIVES(Role) \
+    ((Role) == QUIC_TP_OBSERVED_ADDRESS_ROLE_RECEIVE_ONLY || (Role) == QUIC_TP_OBSERVED_ADDRESS_ROLE_BOTH)
+
 /*************************************************************
                   PERSISTENT SETTINGS
 *************************************************************/
@@ -743,6 +765,8 @@ CXPLAT_STATIC_ASSERT(
 #define QUIC_SETTING_ADD_ADDRESS_MODE               "AddAddressMode"
 #define QUIC_SETTING_IGNORE_UNREACHABLE             "IgnoreUnreachable"
 #define QUIC_SETTING_MULTIPATH_ENABLED              "MultipathEnabled"
+#define QUIC_SETTING_SEND_OBSERVED_ADDRESS_REPORTS    "SendObservedAddressReports"
+#define QUIC_SETTING_RECEIVE_OBSERVED_ADDRESS_REPORTS "ReceiveObservedAddressReports"
 
 
 #define QUIC_SETTING_INITIAL_WINDOW_PACKETS         "InitialWindowPackets"

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -191,6 +191,12 @@ QuicSettingsSetDefault(
     if (!Settings->IsSet.MultipathEnabled) {
         Settings->MultipathEnabled = QUIC_DEFAULT_MULTIPATH_ENABLED;
     }
+    if (!Settings->IsSet.SendObservedAddressReports) {
+        Settings->SendObservedAddressReports = QUIC_DEFAULT_SEND_OBSERVED_ADDRESS_REPORTS;
+    }
+    if (!Settings->IsSet.ReceiveObservedAddressReports) {
+        Settings->ReceiveObservedAddressReports = QUIC_DEFAULT_RECEIVE_OBSERVED_ADDRESS_REPORTS;
+    }
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -381,6 +387,12 @@ QuicSettingsCopy(
     }
     if (!Destination->IsSet.MultipathEnabled) {
         Destination->MultipathEnabled = Source->MultipathEnabled;
+    }
+    if (!Destination->IsSet.SendObservedAddressReports) {
+        Destination->SendObservedAddressReports = Source->SendObservedAddressReports;
+    }
+    if (!Destination->IsSet.ReceiveObservedAddressReports) {
+        Destination->ReceiveObservedAddressReports = Source->ReceiveObservedAddressReports;
     }
 }
 
@@ -809,6 +821,16 @@ QuicSettingApply(
     if (Source->IsSet.MultipathEnabled && (!Destination->IsSet.MultipathEnabled || OverWrite)) {
         Destination->MultipathEnabled = Source->MultipathEnabled;
         Destination->IsSet.MultipathEnabled = TRUE;
+    }
+
+    if (Source->IsSet.SendObservedAddressReports && (!Destination->IsSet.SendObservedAddressReports || OverWrite)) {
+        Destination->SendObservedAddressReports = Source->SendObservedAddressReports;
+        Destination->IsSet.SendObservedAddressReports = TRUE;
+    }
+
+    if (Source->IsSet.ReceiveObservedAddressReports && (!Destination->IsSet.ReceiveObservedAddressReports || OverWrite)) {
+        Destination->ReceiveObservedAddressReports = Source->ReceiveObservedAddressReports;
+        Destination->IsSet.ReceiveObservedAddressReports = TRUE;
     }
 
     return TRUE;
@@ -1551,6 +1573,26 @@ VersionSettingsFail:
             &ValueLen);
         Settings->MultipathEnabled = !!Value;
     }
+    if (!Settings->IsSet.SendObservedAddressReports) {
+        Value = QUIC_DEFAULT_SEND_OBSERVED_ADDRESS_REPORTS;
+        ValueLen = sizeof(Value);
+        CxPlatStorageReadValue(
+            Storage,
+            QUIC_SETTING_SEND_OBSERVED_ADDRESS_REPORTS,
+            (uint8_t*)&Value,
+            &ValueLen);
+        Settings->SendObservedAddressReports = !!Value;
+    }
+    if (!Settings->IsSet.ReceiveObservedAddressReports) {
+        Value = QUIC_DEFAULT_RECEIVE_OBSERVED_ADDRESS_REPORTS;
+        ValueLen = sizeof(Value);
+        CxPlatStorageReadValue(
+            Storage,
+            QUIC_SETTING_RECEIVE_OBSERVED_ADDRESS_REPORTS,
+            (uint8_t*)&Value,
+            &ValueLen);
+        Settings->ReceiveObservedAddressReports = !!Value;
+    }
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -1625,6 +1667,8 @@ QuicSettingsDump(
     QuicTraceLogVerbose(SettingAddAddress,                  "[sett] AddAddressMode         = %hhu", Settings->AddAddressMode);
     QuicTraceLogVerbose(SettingIgnoreUnreachable,           "[sett] IgnoreUnreachable      = %hhu", Settings->IgnoreUnreachable);
     QuicTraceLogVerbose(SettingMultipathEnabled,            "[sett] MultipathEnabled       = %hhu", Settings->MultipathEnabled);
+    QuicTraceLogVerbose(SettingSendObservedAddressReports,  "[sett] SendObservedAddrRpts   = %hhu", Settings->SendObservedAddressReports);
+    QuicTraceLogVerbose(SettingRecvObservedAddressReports,  "[sett] RecvObservedAddrRpts   = %hhu", Settings->ReceiveObservedAddressReports);
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
@@ -1811,6 +1855,12 @@ QuicSettingsDumpNew(
     }
     if (Settings->IsSet.MultipathEnabled) {
         QuicTraceLogVerbose(SettingMultipathEnabled,                "[sett] MultipathEnabled           = %hhu", Settings->MultipathEnabled);
+    }
+    if (Settings->IsSet.SendObservedAddressReports) {
+        QuicTraceLogVerbose(SettingSendObservedAddressReports,      "[sett] SendObservedAddrRpts       = %hhu", Settings->SendObservedAddressReports);
+    }
+    if (Settings->IsSet.ReceiveObservedAddressReports) {
+        QuicTraceLogVerbose(SettingRecvObservedAddressReports,      "[sett] RecvObservedAddrRpts       = %hhu", Settings->ReceiveObservedAddressReports);
     }
 }
 
@@ -2117,6 +2167,22 @@ QuicSettingsSettingsToInternal(
         SettingsSize,
         InternalSettings);
 
+    SETTING_COPY_FLAG_TO_INTERNAL_SIZED(
+        Flags,
+        SendObservedAddressReports,
+        QUIC_SETTINGS,
+        Settings,
+        SettingsSize,
+        InternalSettings);
+
+    SETTING_COPY_FLAG_TO_INTERNAL_SIZED(
+        Flags,
+        ReceiveObservedAddressReports,
+        QUIC_SETTINGS,
+        Settings,
+        SettingsSize,
+        InternalSettings);
+
     return QUIC_STATUS_SUCCESS;
 }
 
@@ -2329,6 +2395,22 @@ QuicSettingsGetSettings(
     SETTING_COPY_FLAG_FROM_INTERNAL_SIZED(
         Flags,
         MultipathEnabled,
+        QUIC_SETTINGS,
+        Settings,
+        *SettingsLength,
+        InternalSettings);
+
+    SETTING_COPY_FLAG_FROM_INTERNAL_SIZED(
+        Flags,
+        SendObservedAddressReports,
+        QUIC_SETTINGS,
+        Settings,
+        *SettingsLength,
+        InternalSettings);
+
+    SETTING_COPY_FLAG_FROM_INTERNAL_SIZED(
+        Flags,
+        ReceiveObservedAddressReports,
         QUIC_SETTINGS,
         Settings,
         *SettingsLength,

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -69,7 +69,9 @@ typedef struct QUIC_SETTINGS_INTERNAL {
             uint64_t AddAddressMode                         : 1;
             uint64_t IgnoreUnreachable                      : 1;
             uint64_t MultipathEnabled                       : 1;
-            uint64_t RESERVED                               : 9;
+            uint64_t SendObservedAddressReports             : 1;
+            uint64_t ReceiveObservedAddressReports          : 1;
+            uint64_t RESERVED                               : 7;
         } IsSet;
     };
 
@@ -127,6 +129,8 @@ typedef struct QUIC_SETTINGS_INTERNAL {
     uint8_t AddAddressMode                  : 2;    // QUIC_ADD_ADDRESS_MODE
     uint8_t IgnoreUnreachable               : 1;
     uint8_t MultipathEnabled                : 1;
+    uint8_t SendObservedAddressReports      : 1;
+    uint8_t ReceiveObservedAddressReports   : 1;
     uint8_t MtuDiscoveryMissingProbeCount;
 } QUIC_SETTINGS_INTERNAL;
 

--- a/src/core/transport_params.h
+++ b/src/core/transport_params.h
@@ -160,6 +160,13 @@ typedef struct QUIC_TRANSPORT_PARAMETERS {
     _Field_range_(0, QUIC_TP_MAX_PATH_ID_MAX)
     QUIC_VAR_INT InitialMaxPathId;
 
+    //
+    // The role advertised by the observed_address transport parameter. Only
+    // meaningful when QUIC_TP_FLAG_OBSERVED_ADDRESS is set.
+    //
+    _Field_range_(0, QUIC_TP_OBSERVED_ADDRESS_ROLE_BOTH)
+    QUIC_VAR_INT ObservedAddressRole;
+
 } QUIC_TRANSPORT_PARAMETERS;
 
 //

--- a/src/core/unittest/SettingsTest.cpp
+++ b/src/core/unittest/SettingsTest.cpp
@@ -133,6 +133,8 @@ TEST(SettingsTest, TestAllSettingsFieldsSet)
     SETTINGS_FEATURE_SET_TEST(AddAddressMode, QuicSettingsSettingsToInternal);
     SETTINGS_FEATURE_SET_TEST(IgnoreUnreachable, QuicSettingsSettingsToInternal);
     SETTINGS_FEATURE_SET_TEST(MultipathEnabled, QuicSettingsSettingsToInternal);
+    SETTINGS_FEATURE_SET_TEST(SendObservedAddressReports, QuicSettingsSettingsToInternal);
+    SETTINGS_FEATURE_SET_TEST(ReceiveObservedAddressReports, QuicSettingsSettingsToInternal);
 
     // Bias field count on behalf of erstwhile ReservedRioEnabled
     FieldCount++;
@@ -228,6 +230,8 @@ TEST(SettingsTest, TestAllSettingsFieldsGet)
     SETTINGS_FEATURE_GET_TEST(AddAddressMode, QuicSettingsGetSettings);
     SETTINGS_FEATURE_GET_TEST(IgnoreUnreachable, QuicSettingsGetSettings);
     SETTINGS_FEATURE_GET_TEST(MultipathEnabled, QuicSettingsGetSettings);
+    SETTINGS_FEATURE_GET_TEST(SendObservedAddressReports, QuicSettingsGetSettings);
+    SETTINGS_FEATURE_GET_TEST(ReceiveObservedAddressReports, QuicSettingsGetSettings);
 
     // Bias field count on behalf of erstwhile ReservedRioEnabled
     FieldCount++;

--- a/src/core/unittest/SpinFrame.cpp
+++ b/src/core/unittest/SpinFrame.cpp
@@ -53,12 +53,14 @@ TEST(SpinFrame, SpinFrame1000000)
     uint8_t BufferLength = 0;
 
     //
-    // FrameType is intentionally uint16_t: the loop below searches for a random
-    // value that satisfies QUIC_FRAME_IS_KNOWN, which only terminates in a
-    // reasonable time over a bounded (16-bit) space. (Frame types wider than
-    // 16 bits — e.g. the address/multipath frames — aren't fuzzed here.)
+    // Only a bounded (16-bit) space is searched below: the loop looks for a
+    // random value that satisfies QUIC_FRAME_IS_KNOWN, which only terminates in
+    // a reasonable time over such a space. (Frame types wider than 16 bits —
+    // e.g. the address/multipath frames — aren't fuzzed here.) FrameType itself
+    // is wider so that case labels for those frame types stay in range.
     //
-    uint16_t FrameType;
+    uint32_t FrameType;
+    uint16_t RandomFrameType;
     CXPLAT_STATIC_ASSERT(
         QUIC_FRAME_MAX_SUPPORTED <= (uint64_t)UINT32_MAX,
         "Tests below assumes frames fit in 32-bits");
@@ -83,7 +85,8 @@ TEST(SpinFrame, SpinFrame1000000)
         }
 
         do {
-            TEST_QUIC_SUCCEEDED(CxPlatRandom(sizeof(FrameType), &FrameType));
+            TEST_QUIC_SUCCEEDED(CxPlatRandom(sizeof(RandomFrameType), &RandomFrameType));
+            FrameType = RandomFrameType;
             //
             // Widen for the check so comparisons against frame types that don't
             // fit in 16 bits (e.g. the address-discovery frames) aren't flagged

--- a/src/core/unittest/TransportParamTest.cpp
+++ b/src/core/unittest/TransportParamTest.cpp
@@ -273,9 +273,17 @@ TEST(TransportParamTest, ReliableResetEnabled)
 
 TEST(TransportParamTest, ObservedAddress)
 {
-    QUIC_TRANSPORT_PARAMETERS OriginalTP;
-    CxPlatZeroMemory(&OriginalTP, sizeof(OriginalTP));
-    OriginalTP.Flags = QUIC_TP_FLAG_OBSERVED_ADDRESS;
-    EncodeDecodeAndCompare(&OriginalTP);
-    EncodeDecodeAndCompare(&OriginalTP, true);
+    const QUIC_VAR_INT Roles[] = {
+        QUIC_TP_OBSERVED_ADDRESS_ROLE_SEND_ONLY,
+        QUIC_TP_OBSERVED_ADDRESS_ROLE_RECEIVE_ONLY,
+        QUIC_TP_OBSERVED_ADDRESS_ROLE_BOTH
+    };
+    for (size_t i = 0; i < ARRAYSIZE(Roles); ++i) {
+        QUIC_TRANSPORT_PARAMETERS OriginalTP;
+        CxPlatZeroMemory(&OriginalTP, sizeof(OriginalTP));
+        OriginalTP.Flags = QUIC_TP_FLAG_OBSERVED_ADDRESS;
+        OriginalTP.ObservedAddressRole = Roles[i];
+        EncodeDecodeAndCompare(&OriginalTP);
+        EncodeDecodeAndCompare(&OriginalTP, true);
+    }
 }

--- a/src/generated/linux/settings.c.clog.h
+++ b/src/generated/linux/settings.c.clog.h
@@ -873,6 +873,36 @@ tracepoint(CLOG_SETTINGS_C, SettingMultipathEnabled , arg2);\
 
 
 /*----------------------------------------------------------
+// Decoder Ring for SettingSendObservedAddressReports
+// [sett] SendObservedAddrRpts   = %hhu
+// QuicTraceLogVerbose(SettingSendObservedAddressReports,  "[sett] SendObservedAddrRpts   = %hhu", Settings->SendObservedAddressReports);
+// arg2 = arg2 = Settings->SendObservedAddressReports = arg2
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_SettingSendObservedAddressReports
+#define _clog_3_ARGS_TRACE_SettingSendObservedAddressReports(uniqueId, encoded_arg_string, arg2)\
+tracepoint(CLOG_SETTINGS_C, SettingSendObservedAddressReports , arg2);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for SettingRecvObservedAddressReports
+// [sett] RecvObservedAddrRpts   = %hhu
+// QuicTraceLogVerbose(SettingRecvObservedAddressReports,  "[sett] RecvObservedAddrRpts   = %hhu", Settings->ReceiveObservedAddressReports);
+// arg2 = arg2 = Settings->ReceiveObservedAddressReports = arg2
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_SettingRecvObservedAddressReports
+#define _clog_3_ARGS_TRACE_SettingRecvObservedAddressReports(uniqueId, encoded_arg_string, arg2)\
+tracepoint(CLOG_SETTINGS_C, SettingRecvObservedAddressReports , arg2);\
+
+#endif
+
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for SettingDumpLFixedServerID
 // [sett] FixedServerID          = %u
 // QuicTraceLogVerbose(SettingDumpLFixedServerID,              "[sett] FixedServerID          = %u", Settings->FixedServerID);

--- a/src/generated/linux/settings.c.clog.h.lttng.h
+++ b/src/generated/linux/settings.c.clog.h.lttng.h
@@ -907,6 +907,38 @@ TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingMultipathEnabled,
 
 
 /*----------------------------------------------------------
+// Decoder Ring for SettingSendObservedAddressReports
+// [sett] SendObservedAddrRpts   = %hhu
+// QuicTraceLogVerbose(SettingSendObservedAddressReports,  "[sett] SendObservedAddrRpts   = %hhu", Settings->SendObservedAddressReports);
+// arg2 = arg2 = Settings->SendObservedAddressReports = arg2
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingSendObservedAddressReports,
+    TP_ARGS(
+        unsigned char, arg2), 
+    TP_FIELDS(
+        ctf_integer(unsigned char, arg2, arg2)
+    )
+)
+
+
+
+/*----------------------------------------------------------
+// Decoder Ring for SettingRecvObservedAddressReports
+// [sett] RecvObservedAddrRpts   = %hhu
+// QuicTraceLogVerbose(SettingRecvObservedAddressReports,  "[sett] RecvObservedAddrRpts   = %hhu", Settings->ReceiveObservedAddressReports);
+// arg2 = arg2 = Settings->ReceiveObservedAddressReports = arg2
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_SETTINGS_C, SettingRecvObservedAddressReports,
+    TP_ARGS(
+        unsigned char, arg2), 
+    TP_FIELDS(
+        ctf_integer(unsigned char, arg2, arg2)
+    )
+)
+
+
+
+/*----------------------------------------------------------
 // Decoder Ring for SettingDumpLFixedServerID
 // [sett] FixedServerID          = %u
 // QuicTraceLogVerbose(SettingDumpLFixedServerID,              "[sett] FixedServerID          = %u", Settings->FixedServerID);

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -851,7 +851,9 @@ typedef struct QUIC_SETTINGS {
             uint64_t AddAddressMode                         : 1;
             uint64_t IgnoreUnreachable                      : 1;
             uint64_t MultipathEnabled                       : 1;
-            uint64_t RESERVED                               : 14;
+            uint64_t SendObservedAddressReports             : 1;
+            uint64_t ReceiveObservedAddressReports          : 1;
+            uint64_t RESERVED                               : 12;
 #else
             uint64_t RESERVED                               : 26;
 #endif
@@ -908,7 +910,9 @@ typedef struct QUIC_SETTINGS {
             uint64_t ServerMigrationEnabled    : 1;
             uint64_t IgnoreUnreachable         : 1;
             uint64_t MultipathEnabled          : 1;
-            uint64_t ReservedFlags             : 52;
+            uint64_t SendObservedAddressReports    : 1;
+            uint64_t ReceiveObservedAddressReports : 1;
+            uint64_t ReservedFlags             : 50;
 #else
             uint64_t ReservedFlags             : 63;
 #endif

--- a/src/inc/msquic.hpp
+++ b/src/inc/msquic.hpp
@@ -748,6 +748,8 @@ public:
     MsQuicSettings& SetServerMigrationEnabled(bool value) { ServerMigrationEnabled = value; IsSet.ServerMigrationEnabled = TRUE; return *this; }
     MsQuicSettings& SetIgnoreUnreachable(bool value) { IgnoreUnreachable = value; IsSet.IgnoreUnreachable = TRUE; return *this; }
     MsQuicSettings& SetMultipathEnabled(bool value) { MultipathEnabled = value; IsSet.MultipathEnabled = TRUE; return *this; }
+    MsQuicSettings& SetSendObservedAddressReports(bool value) { SendObservedAddressReports = value; IsSet.SendObservedAddressReports = TRUE; return *this; }
+    MsQuicSettings& SetReceiveObservedAddressReports(bool value) { ReceiveObservedAddressReports = value; IsSet.ReceiveObservedAddressReports = TRUE; return *this; }
 #endif
 
     QUIC_STATUS

--- a/src/manifest/clog.sidecar
+++ b/src/manifest/clog.sidecar
@@ -12557,10 +12557,34 @@
       ],
       "macroName": "QuicTraceLogVerbose"
     },
+    "SettingRecvObservedAddressReports": {
+      "ModuleProperites": {},
+      "TraceString": "[sett] RecvObservedAddrRpts   = %hhu",
+      "UniqueId": "SettingRecvObservedAddressReports",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
     "SettingReliableResetEnabled": {
       "ModuleProperites": {},
       "TraceString": "[sett] ReliableResetEnabled   = %hhu",
       "UniqueId": "SettingReliableResetEnabled",
+      "splitArgs": [
+        {
+          "DefinationEncoding": "hhu",
+          "MacroVariableName": "arg2"
+        }
+      ],
+      "macroName": "QuicTraceLogVerbose"
+    },
+    "SettingSendObservedAddressReports": {
+      "ModuleProperites": {},
+      "TraceString": "[sett] SendObservedAddrRpts   = %hhu",
+      "UniqueId": "SettingSendObservedAddressReports",
       "splitArgs": [
         {
           "DefinationEncoding": "hhu",
@@ -18591,9 +18615,19 @@
         "EncodingString": "[sett] QTIPEnabled            = %hhu"
       },
       {
+        "UniquenessHash": "6a871112-6ce4-00b3-9125-13ce54568a3e",
+        "TraceID": "SettingRecvObservedAddressReports",
+        "EncodingString": "[sett] RecvObservedAddrRpts   = %hhu"
+      },
+      {
         "UniquenessHash": "f5c7d703-ecd1-8dd0-c16d-11857945bfcf",
         "TraceID": "SettingReliableResetEnabled",
         "EncodingString": "[sett] ReliableResetEnabled   = %hhu"
+      },
+      {
+        "UniquenessHash": "21cebed1-c968-5505-1540-f8e2c3257d52",
+        "TraceID": "SettingSendObservedAddressReports",
+        "EncodingString": "[sett] SendObservedAddrRpts   = %hhu"
       },
       {
         "UniquenessHash": "efb76d23-a243-d5cb-a1cc-2dc5dba5454b",

--- a/src/rs/ffi/linux_bindings.rs
+++ b/src/rs/ffi/linux_bindings.rs
@@ -3749,14 +3749,80 @@ impl QUIC_SETTINGS__bindgen_ty_1__bindgen_ty_1 {
         }
     }
     #[inline]
+    pub fn SendObservedAddressReports(&self) -> u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(50usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_SendObservedAddressReports(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(50usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn SendObservedAddressReports_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 8usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                50usize,
+                1u8,
+            ) as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_SendObservedAddressReports_raw(this: *mut Self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 8usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                50usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn ReceiveObservedAddressReports(&self) -> u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(51usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_ReceiveObservedAddressReports(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(51usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn ReceiveObservedAddressReports_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 8usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                51usize,
+                1u8,
+            ) as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_ReceiveObservedAddressReports_raw(this: *mut Self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 8usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                51usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
     pub fn RESERVED(&self) -> u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(50usize, 14u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(52usize, 12u8) as u64) }
     }
     #[inline]
     pub fn set_RESERVED(&mut self, val: u64) {
         unsafe {
             let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(50usize, 14u8, val as u64)
+            self._bitfield_1.set(52usize, 12u8, val as u64)
         }
     }
     #[inline]
@@ -3764,8 +3830,8 @@ impl QUIC_SETTINGS__bindgen_ty_1__bindgen_ty_1 {
         unsafe {
             ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 8usize]>>::raw_get(
                 ::std::ptr::addr_of!((*this)._bitfield_1),
-                50usize,
-                14u8,
+                52usize,
+                12u8,
             ) as u64)
         }
     }
@@ -3775,8 +3841,8 @@ impl QUIC_SETTINGS__bindgen_ty_1__bindgen_ty_1 {
             let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<[u8; 8usize]>>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                50usize,
-                14u8,
+                52usize,
+                12u8,
                 val as u64,
             )
         }
@@ -3833,6 +3899,8 @@ impl QUIC_SETTINGS__bindgen_ty_1__bindgen_ty_1 {
         AddAddressMode: u64,
         IgnoreUnreachable: u64,
         MultipathEnabled: u64,
+        SendObservedAddressReports: u64,
+        ReceiveObservedAddressReports: u64,
         RESERVED: u64,
     ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
@@ -4059,7 +4127,17 @@ impl QUIC_SETTINGS__bindgen_ty_1__bindgen_ty_1 {
             let MultipathEnabled: u64 = unsafe { ::std::mem::transmute(MultipathEnabled) };
             MultipathEnabled as u64
         });
-        __bindgen_bitfield_unit.set(50usize, 14u8, {
+        __bindgen_bitfield_unit.set(50usize, 1u8, {
+            let SendObservedAddressReports: u64 =
+                unsafe { ::std::mem::transmute(SendObservedAddressReports) };
+            SendObservedAddressReports as u64
+        });
+        __bindgen_bitfield_unit.set(51usize, 1u8, {
+            let ReceiveObservedAddressReports: u64 =
+                unsafe { ::std::mem::transmute(ReceiveObservedAddressReports) };
+            ReceiveObservedAddressReports as u64
+        });
+        __bindgen_bitfield_unit.set(52usize, 12u8, {
             let RESERVED: u64 = unsafe { ::std::mem::transmute(RESERVED) };
             RESERVED as u64
         });
@@ -4494,14 +4572,80 @@ impl QUIC_SETTINGS__bindgen_ty_2__bindgen_ty_1 {
         }
     }
     #[inline]
+    pub fn SendObservedAddressReports(&self) -> u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(12usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_SendObservedAddressReports(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(12usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn SendObservedAddressReports_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 8usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                12usize,
+                1u8,
+            ) as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_SendObservedAddressReports_raw(this: *mut Self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 8usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                12usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn ReceiveObservedAddressReports(&self) -> u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(13usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_ReceiveObservedAddressReports(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(13usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn ReceiveObservedAddressReports_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 8usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                13usize,
+                1u8,
+            ) as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_ReceiveObservedAddressReports_raw(this: *mut Self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 8usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                13usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
     pub fn ReservedFlags(&self) -> u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(12usize, 52u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(14usize, 50u8) as u64) }
     }
     #[inline]
     pub fn set_ReservedFlags(&mut self, val: u64) {
         unsafe {
             let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(12usize, 52u8, val as u64)
+            self._bitfield_1.set(14usize, 50u8, val as u64)
         }
     }
     #[inline]
@@ -4509,8 +4653,8 @@ impl QUIC_SETTINGS__bindgen_ty_2__bindgen_ty_1 {
         unsafe {
             ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 8usize]>>::raw_get(
                 ::std::ptr::addr_of!((*this)._bitfield_1),
-                12usize,
-                52u8,
+                14usize,
+                50u8,
             ) as u64)
         }
     }
@@ -4520,8 +4664,8 @@ impl QUIC_SETTINGS__bindgen_ty_2__bindgen_ty_1 {
             let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<[u8; 8usize]>>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                12usize,
-                52u8,
+                14usize,
+                50u8,
                 val as u64,
             )
         }
@@ -4540,6 +4684,8 @@ impl QUIC_SETTINGS__bindgen_ty_2__bindgen_ty_1 {
         ServerMigrationEnabled: u64,
         IgnoreUnreachable: u64,
         MultipathEnabled: u64,
+        SendObservedAddressReports: u64,
+        ReceiveObservedAddressReports: u64,
         ReservedFlags: u64,
     ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
@@ -4594,7 +4740,17 @@ impl QUIC_SETTINGS__bindgen_ty_2__bindgen_ty_1 {
             let MultipathEnabled: u64 = unsafe { ::std::mem::transmute(MultipathEnabled) };
             MultipathEnabled as u64
         });
-        __bindgen_bitfield_unit.set(12usize, 52u8, {
+        __bindgen_bitfield_unit.set(12usize, 1u8, {
+            let SendObservedAddressReports: u64 =
+                unsafe { ::std::mem::transmute(SendObservedAddressReports) };
+            SendObservedAddressReports as u64
+        });
+        __bindgen_bitfield_unit.set(13usize, 1u8, {
+            let ReceiveObservedAddressReports: u64 =
+                unsafe { ::std::mem::transmute(ReceiveObservedAddressReports) };
+            ReceiveObservedAddressReports as u64
+        });
+        __bindgen_bitfield_unit.set(14usize, 50u8, {
             let ReservedFlags: u64 = unsafe { ::std::mem::transmute(ReservedFlags) };
             ReservedFlags as u64
         });

--- a/src/rs/ffi/win_bindings.rs
+++ b/src/rs/ffi/win_bindings.rs
@@ -3742,14 +3742,80 @@ impl QUIC_SETTINGS__bindgen_ty_1__bindgen_ty_1 {
         }
     }
     #[inline]
+    pub fn SendObservedAddressReports(&self) -> u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(50usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_SendObservedAddressReports(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(50usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn SendObservedAddressReports_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 8usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                50usize,
+                1u8,
+            ) as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_SendObservedAddressReports_raw(this: *mut Self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 8usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                50usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn ReceiveObservedAddressReports(&self) -> u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(51usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_ReceiveObservedAddressReports(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(51usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn ReceiveObservedAddressReports_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 8usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                51usize,
+                1u8,
+            ) as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_ReceiveObservedAddressReports_raw(this: *mut Self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 8usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                51usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
     pub fn RESERVED(&self) -> u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(50usize, 14u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(52usize, 12u8) as u64) }
     }
     #[inline]
     pub fn set_RESERVED(&mut self, val: u64) {
         unsafe {
             let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(50usize, 14u8, val as u64)
+            self._bitfield_1.set(52usize, 12u8, val as u64)
         }
     }
     #[inline]
@@ -3757,8 +3823,8 @@ impl QUIC_SETTINGS__bindgen_ty_1__bindgen_ty_1 {
         unsafe {
             ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 8usize]>>::raw_get(
                 ::std::ptr::addr_of!((*this)._bitfield_1),
-                50usize,
-                14u8,
+                52usize,
+                12u8,
             ) as u64)
         }
     }
@@ -3768,8 +3834,8 @@ impl QUIC_SETTINGS__bindgen_ty_1__bindgen_ty_1 {
             let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<[u8; 8usize]>>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                50usize,
-                14u8,
+                52usize,
+                12u8,
                 val as u64,
             )
         }
@@ -3826,6 +3892,8 @@ impl QUIC_SETTINGS__bindgen_ty_1__bindgen_ty_1 {
         AddAddressMode: u64,
         IgnoreUnreachable: u64,
         MultipathEnabled: u64,
+        SendObservedAddressReports: u64,
+        ReceiveObservedAddressReports: u64,
         RESERVED: u64,
     ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
@@ -4052,7 +4120,17 @@ impl QUIC_SETTINGS__bindgen_ty_1__bindgen_ty_1 {
             let MultipathEnabled: u64 = unsafe { ::std::mem::transmute(MultipathEnabled) };
             MultipathEnabled as u64
         });
-        __bindgen_bitfield_unit.set(50usize, 14u8, {
+        __bindgen_bitfield_unit.set(50usize, 1u8, {
+            let SendObservedAddressReports: u64 =
+                unsafe { ::std::mem::transmute(SendObservedAddressReports) };
+            SendObservedAddressReports as u64
+        });
+        __bindgen_bitfield_unit.set(51usize, 1u8, {
+            let ReceiveObservedAddressReports: u64 =
+                unsafe { ::std::mem::transmute(ReceiveObservedAddressReports) };
+            ReceiveObservedAddressReports as u64
+        });
+        __bindgen_bitfield_unit.set(52usize, 12u8, {
             let RESERVED: u64 = unsafe { ::std::mem::transmute(RESERVED) };
             RESERVED as u64
         });
@@ -4487,14 +4565,80 @@ impl QUIC_SETTINGS__bindgen_ty_2__bindgen_ty_1 {
         }
     }
     #[inline]
+    pub fn SendObservedAddressReports(&self) -> u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(12usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_SendObservedAddressReports(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(12usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn SendObservedAddressReports_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 8usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                12usize,
+                1u8,
+            ) as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_SendObservedAddressReports_raw(this: *mut Self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 8usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                12usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn ReceiveObservedAddressReports(&self) -> u64 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(13usize, 1u8) as u64) }
+    }
+    #[inline]
+    pub fn set_ReceiveObservedAddressReports(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set(13usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn ReceiveObservedAddressReports_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 8usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                13usize,
+                1u8,
+            ) as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_ReceiveObservedAddressReports_raw(this: *mut Self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 8usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                13usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
     pub fn ReservedFlags(&self) -> u64 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(12usize, 52u8) as u64) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(14usize, 50u8) as u64) }
     }
     #[inline]
     pub fn set_ReservedFlags(&mut self, val: u64) {
         unsafe {
             let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set(12usize, 52u8, val as u64)
+            self._bitfield_1.set(14usize, 50u8, val as u64)
         }
     }
     #[inline]
@@ -4502,8 +4646,8 @@ impl QUIC_SETTINGS__bindgen_ty_2__bindgen_ty_1 {
         unsafe {
             ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 8usize]>>::raw_get(
                 ::std::ptr::addr_of!((*this)._bitfield_1),
-                12usize,
-                52u8,
+                14usize,
+                50u8,
             ) as u64)
         }
     }
@@ -4513,8 +4657,8 @@ impl QUIC_SETTINGS__bindgen_ty_2__bindgen_ty_1 {
             let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<[u8; 8usize]>>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                12usize,
-                52u8,
+                14usize,
+                50u8,
                 val as u64,
             )
         }
@@ -4533,6 +4677,8 @@ impl QUIC_SETTINGS__bindgen_ty_2__bindgen_ty_1 {
         ServerMigrationEnabled: u64,
         IgnoreUnreachable: u64,
         MultipathEnabled: u64,
+        SendObservedAddressReports: u64,
+        ReceiveObservedAddressReports: u64,
         ReservedFlags: u64,
     ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
@@ -4587,7 +4733,17 @@ impl QUIC_SETTINGS__bindgen_ty_2__bindgen_ty_1 {
             let MultipathEnabled: u64 = unsafe { ::std::mem::transmute(MultipathEnabled) };
             MultipathEnabled as u64
         });
-        __bindgen_bitfield_unit.set(12usize, 52u8, {
+        __bindgen_bitfield_unit.set(12usize, 1u8, {
+            let SendObservedAddressReports: u64 =
+                unsafe { ::std::mem::transmute(SendObservedAddressReports) };
+            SendObservedAddressReports as u64
+        });
+        __bindgen_bitfield_unit.set(13usize, 1u8, {
+            let ReceiveObservedAddressReports: u64 =
+                unsafe { ::std::mem::transmute(ReceiveObservedAddressReports) };
+            ReceiveObservedAddressReports as u64
+        });
+        __bindgen_bitfield_unit.set(14usize, 50u8, {
             let ReservedFlags: u64 = unsafe { ::std::mem::transmute(ReservedFlags) };
             ReservedFlags as u64
         });

--- a/src/rs/settings.rs
+++ b/src/rs/settings.rs
@@ -208,6 +208,10 @@ impl Settings {
     define_settings_entry_bitflag2!(set_IgnoreUnreachable);
     #[cfg(feature = "preview-api")]
     define_settings_entry_bitflag2!(set_MultipathEnabled);
+    #[cfg(feature = "preview-api")]
+    define_settings_entry_bitflag2!(set_SendObservedAddressReports);
+    #[cfg(feature = "preview-api")]
+    define_settings_entry_bitflag2!(set_ReceiveObservedAddressReports);
 
     define_settings_entry!(
         set_StreamRecvWindowBidiLocalDefault,

--- a/src/test/lib/EventTest.cpp
+++ b/src/test/lib/EventTest.cpp
@@ -385,22 +385,12 @@ QuicTestValidateConnectionEvents1(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     ConnValidator Client(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [5] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [4] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     ConnValidator Server(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
@@ -461,17 +451,6 @@ QuicTestValidateConnectionEvents2(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     ConnValidator Client(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [7] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED, 0, true), // TODO - Schannel does resumption regardless
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [6] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
@@ -480,14 +459,12 @@ QuicTestValidateConnectionEvents2(
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     ConnValidator Server(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [5] {
+        new(std::nothrow) ConnEventValidator* [4] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_PATH_VALIDATED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         },
@@ -551,22 +528,12 @@ QuicTestValidateConnectionEvents3(
     }
 
     ConnValidator Client(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [5] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION, false, true),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [4] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION, false, true),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     ConnValidator Server(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
@@ -676,22 +643,12 @@ QuicTestValidateNetStatsConnEvent1(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     ConnValidator Client(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [5] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [4] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     ConnValidator Server(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
@@ -771,22 +728,12 @@ QuicTestValidateNetStatsConnEvent2(
     TEST_TRUE(ClientConfiguration.IsValid());
 
     ConnValidator Client(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [5] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [4] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     ConnValidator Server(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
@@ -934,18 +881,6 @@ QuicTestValidateStreamEvents1(
         });
 
     Client.SetExpectedEvents(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [8] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED, 0, true), // TODO - Schannel does resumption regardless
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [7] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
@@ -955,14 +890,12 @@ QuicTestValidateStreamEvents1(
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     Server.SetExpectedEvents(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [7] {
+        new(std::nothrow) ConnEventValidator* [6] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_PATH_VALIDATED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
             new(std::nothrow) NewStreamEventValidator(&ServerStream),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
@@ -1053,19 +986,6 @@ QuicTestValidateStreamEvents2(
         });
 
     Client.SetExpectedEvents(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [9] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED, QUIC_EVENT_ACTION_SHUTDOWN_CONNECTION),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED, 0, true), // TODO - Schannel does resumption regardless
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [8] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
@@ -1076,7 +996,6 @@ QuicTestValidateStreamEvents2(
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     Server.SetExpectedEvents(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
@@ -1178,18 +1097,6 @@ QuicTestValidateStreamEvents3(
         });
 
     Client.SetExpectedEvents(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [8] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED, 0, true), // TODO - Schannel does resumption regardless
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [7] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
@@ -1199,14 +1106,12 @@ QuicTestValidateStreamEvents3(
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     Server.SetExpectedEvents(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [7] {
+        new(std::nothrow) ConnEventValidator* [6] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_PATH_VALIDATED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
             new(std::nothrow) NewStreamEventValidator(&ServerStream),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
@@ -1328,18 +1233,6 @@ QuicTestValidateStreamEvents4(
         });
 
     Client.SetExpectedEvents(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [8] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED, 0, true), // TODO - Schannel does resumption regardless
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [7] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
@@ -1349,14 +1242,12 @@ QuicTestValidateStreamEvents4(
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     Server.SetExpectedEvents(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [7] {
+        new(std::nothrow) ConnEventValidator* [6] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_PATH_VALIDATED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
             new(std::nothrow) NewStreamEventValidator(&ServerStream),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
@@ -1478,18 +1369,6 @@ QuicTestValidateStreamEvents5(
         });
 
     Client.SetExpectedEvents(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [8] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED, 0, true), // TODO - Schannel does resumption regardless
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [7] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
@@ -1499,14 +1378,12 @@ QuicTestValidateStreamEvents5(
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     Server.SetExpectedEvents(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [7] {
+        new(std::nothrow) ConnEventValidator* [6] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_PATH_VALIDATED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
             new(std::nothrow) NewStreamEventValidator(&ServerStream),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
@@ -1607,18 +1484,6 @@ QuicTestValidateStreamEvents6(
         });
 
     Client.SetExpectedEvents(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [8] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED, 0, true), // TODO - Schannel does resumption regardless
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [7] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
@@ -1628,14 +1493,12 @@ QuicTestValidateStreamEvents6(
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     Server.SetExpectedEvents(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [7] {
+        new(std::nothrow) ConnEventValidator* [6] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_PATH_VALIDATED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
             new(std::nothrow) NewStreamEventValidator(&ServerStream),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
@@ -1749,18 +1612,6 @@ QuicTestValidateStreamEvents7(
         });
 
     Client.SetExpectedEvents(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [8] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED, 0, true), // TODO - Schannel does resumption regardless
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [7] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
@@ -1770,14 +1621,12 @@ QuicTestValidateStreamEvents7(
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     Server.SetExpectedEvents(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [7] {
+        new(std::nothrow) ConnEventValidator* [6] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_PATH_VALIDATED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
             new(std::nothrow) NewStreamEventValidator(&ServerStream),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
@@ -1891,18 +1740,6 @@ QuicTestValidateStreamEvents8(
         });
 
     Client.SetExpectedEvents(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [8] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED, 0, true), // TODO - Schannel does resumption regardless
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [7] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
@@ -1912,14 +1749,12 @@ QuicTestValidateStreamEvents8(
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     Server.SetExpectedEvents(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [7] {
+        new(std::nothrow) ConnEventValidator* [6] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_PATH_VALIDATED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
             new(std::nothrow) NewStreamEventValidator(&ServerStream),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
@@ -2041,19 +1876,6 @@ QuicTestValidateStreamEvents9(
         });
 
     Client.SetExpectedEvents(
-#ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [9] {
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RELIABLE_RESET_NEGOTIATED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE, 0, true),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RESUMPTION_TICKET_RECEIVED, 0, true), // TODO - Schannel does resumption regardless
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
-            nullptr
-        }
-#else
         new(std::nothrow) ConnEventValidator* [8] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RELIABLE_RESET_NEGOTIATED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_STREAMS_AVAILABLE),
@@ -2064,15 +1886,13 @@ QuicTestValidateStreamEvents9(
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),
             nullptr
         }
-#endif
     );
     Server.SetExpectedEvents(
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
-        new(std::nothrow) ConnEventValidator* [8] {
+        new(std::nothrow) ConnEventValidator* [7] {
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_RELIABLE_RESET_NEGOTIATED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_PATH_VALIDATED),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_CONNECTED),
-            new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS),
             new(std::nothrow) NewStreamEventValidator(&ServerStream),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER),
             new(std::nothrow) ConnEventValidator(QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE),

--- a/src/test/lib/PathTest.cpp
+++ b/src/test/lib/PathTest.cpp
@@ -830,11 +830,17 @@ QuicTestAddressDiscovery(
     MsQuicRegistration Registration(true);
     TEST_TRUE(Registration.IsValid());
 
-    MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", ServerSelfSignedCredConfig);
+    //
+    // Address discovery is opt-in, and this test expects both sides to report
+    // the peer's observed address, so enable both directions on both ends.
+    //
+    MsQuicSettings Settings;
+    Settings.SetSendObservedAddressReports(TRUE).SetReceiveObservedAddressReports(TRUE);
+    MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", Settings, ServerSelfSignedCredConfig);
     TEST_TRUE(ServerConfiguration.IsValid());
 
     MsQuicCredentialConfig ClientCredConfig;
-    MsQuicConfiguration ClientConfiguration(Registration, "MsQuicTest", ClientCredConfig);
+    MsQuicConfiguration ClientConfiguration(Registration, "MsQuicTest", Settings, ClientCredConfig);
     TEST_TRUE(ClientConfiguration.IsValid());
 
     MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, AddressDiscoveryTestContext::ConnCallback, &ServerContext);

--- a/src/tools/sample/sample.c
+++ b/src/tools/sample/sample.c
@@ -447,6 +447,19 @@ ServerConnectionCallback(
         MsQuic->ConnectionSendResumptionTicket(Connection, QUIC_SEND_RESUMPTION_FLAG_NONE, 0, NULL);
         break;
     }
+    case QUIC_CONNECTION_EVENT_NOTIFY_OBSERVED_ADDRESS: {
+        QUIC_ADDR_STR AddrStr = {0};
+        QUIC_ADDR_STR AddrStr1 = {0};
+        if (QuicAddrToString(Event->NOTIFY_OBSERVED_ADDRESS.LocalAddress, &AddrStr) &&
+            QuicAddrToString(Event->NOTIFY_OBSERVED_ADDRESS.ObservedAddress, &AddrStr1)) {
+            printf(
+                "[conn][%p] Local Address: %s Observed Address: %s\n",
+                Connection,
+                AddrStr.Address,
+                AddrStr1.Address);
+        }
+        break;
+    }
     case QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_TRANSPORT:
         //
         // The connection has been shut down by the transport. Generally, this

--- a/src/tools/sample/sample.c
+++ b/src/tools/sample/sample.c
@@ -137,6 +137,10 @@ void PrintUsage()
 #endif
         "  quicsample.exe -server -cert_hash:<...>\n"
         "  quicsample.exe -server -cert_file:<...> -key_file:<...> [-password:<...>]\n"
+        "\n"
+        "Both client and server accept -multipath, plus -observed_address_send and\n"
+        "-observed_address_recv to opt in to either direction of the address\n"
+        "discovery extension (both are off by default).\n"
         );
 }
 
@@ -577,6 +581,14 @@ ServerLoadConfiguration(
         Settings.MultipathEnabled = TRUE;
         MultipathEnabled = TRUE;
     }
+    if (GetFlag(argc, argv, "observed_address_send")) {
+        Settings.IsSet.SendObservedAddressReports = TRUE;
+        Settings.SendObservedAddressReports = TRUE;
+    }
+    if (GetFlag(argc, argv, "observed_address_recv")) {
+        Settings.IsSet.ReceiveObservedAddressReports = TRUE;
+        Settings.ReceiveObservedAddressReports = TRUE;
+    }
 
     QUIC_CREDENTIAL_CONFIG_HELPER Config;
     memset(&Config, 0, sizeof(Config));
@@ -983,7 +995,9 @@ ClientConnectionCallback(
 BOOLEAN
 ClientLoadConfiguration(
     BOOLEAN Unsecure,
-    BOOLEAN Multipath
+    BOOLEAN Multipath,
+    BOOLEAN ObservedAddressSend,
+    BOOLEAN ObservedAddressRecv
     )
 {
     QUIC_SETTINGS Settings = {0};
@@ -996,6 +1010,14 @@ ClientLoadConfiguration(
         Settings.IsSet.MultipathEnabled = TRUE;
         Settings.MultipathEnabled = TRUE;
         MultipathEnabled = TRUE;
+    }
+    if (ObservedAddressSend) {
+        Settings.IsSet.SendObservedAddressReports = TRUE;
+        Settings.SendObservedAddressReports = TRUE;
+    }
+    if (ObservedAddressRecv) {
+        Settings.IsSet.ReceiveObservedAddressReports = TRUE;
+        Settings.ReceiveObservedAddressReports = TRUE;
     }
 
     //
@@ -1044,7 +1066,11 @@ RunClient(
     //
     // Load the client configuration based on the "unsecure" command line option.
     //
-    if (!ClientLoadConfiguration(GetFlag(argc, argv, "unsecure"), GetFlag(argc, argv, "multipath"))) {
+    if (!ClientLoadConfiguration(
+            GetFlag(argc, argv, "unsecure"),
+            GetFlag(argc, argv, "multipath"),
+            GetFlag(argc, argv, "observed_address_send"),
+            GetFlag(argc, argv, "observed_address_recv"))) {
         return;
     }
 
@@ -1131,7 +1157,11 @@ RunMultiClient(
     //
     // Load the client configuration based on the "unsecure" command line option.
     //
-    if (!ClientLoadConfiguration(GetFlag(argc, argv, "unsecure"), GetFlag(argc, argv, "multipath"))) {
+    if (!ClientLoadConfiguration(
+            GetFlag(argc, argv, "unsecure"),
+            GetFlag(argc, argv, "multipath"),
+            GetFlag(argc, argv, "observed_address_send"),
+            GetFlag(argc, argv, "observed_address_recv"))) {
         return;
     }
     QUIC_STATUS Status = QUIC_STATUS_SUCCESS;


### PR DESCRIPTION
Two commits against the address discovery extension.

## 1. Use draft codepoints for OBSERVED_ADDRESS frame types

`QUIC_FRAME_OBSERVED_ADDRESS_V4`/`_V6` in `src/core/frame.h` were `0x9f81`/`0x9f82`, with the draft-ietf-quic-address-discovery codepoints (`0x9f81a6`/`0x9f81a7`) left only as a trailing comment.

The transport parameter ID (`QUIC_TP_ID_OBSERVED_ADDRESS = 0x9f81a176`) already matches the draft, so the extension **negotiates successfully** with other implementations — and only then do the frames themselves fail to parse. Reproduced against [noq](https://crates.io/crates/noq) 1.0.1 (quinn-based, draft codepoints) over loopback:

```
quicsample: Connected -> Shut down by transport, 0x5   (QUIC_STATUS_INTERNAL_ERROR)
noq server: aborted by peer: received a frame that was badly formatted
```

`src/plugins/dbg/quictypes.h` already carried the correct draft values, so the two enums were out of sync.

`src/core/unittest/SpinFrame.cpp` widens `FrameType` to `uint32_t` so the `case` labels stay within the switch operand's range (`-Werror=switch-outside-range` otherwise fails the build). The fuzzed value is still drawn from the 16-bit space, exactly as before.

## 2. Add opt-in settings for observed address reports

The extension was unconditionally enabled: msquic always advertised the transport parameter, always sent it with a hardcoded value of `2` ("both"), discarded the peer's value (the `TODO - Pass value?` in `crypto_tls.c`), and always accepted OBSERVED_ADDRESS frames. An app had no way to turn any of it off.

Two new settings, mirroring the noq/quinn API:

| Setting | Default | Meaning |
|---|---|---|
| `SendObservedAddressReports` | `FALSE` | Report the peer's observed address to it |
| `ReceiveObservedAddressReports` | `FALSE` | Ask the peer to report ours |

- **The extension is now opt-in.** Previously it was always on; both settings default to `FALSE`.
- The transport parameter is sent only when at least one direction is enabled, and its value now states which — `SEND_ONLY` (0) / `RECEIVE_ONLY` (1) / `BOTH` (2), per the draft.
- The peer's value is kept in `QUIC_TRANSPORT_PARAMETERS::ObservedAddressRole` and honored: frames are sent only when this endpoint enabled sending **and** the peer asked to receive.
- An OBSERVED_ADDRESS frame arriving when we never asked to receive one is now a `PROTOCOL_VIOLATION` instead of being silently accepted.
- `quicsample` gains `-observed_address_send` / `-observed_address_recv` on both client and server.

Plumbed through the usual places: `msquic.h` (IsSet + Flags bits), `msquic.hpp` setters, `settings.h`/`settings.c` (defaults, copy, apply, registry load, both dumps, to/from-internal), `quicdef.h` defaults and registry names, `docs/Settings.md`, `SettingsTest` SET+GET entries. Clog headers and `clog.sidecar` were regenerated with the clog tool from `submodules/clog`.

## Verification

Loopback against `noq-mp-sample` (unmodified; noq enables both directions), with the rebuilt `quicsample`:

**Frame codepoints — before commit 1:**

| Scenario | Result |
|---|---|
| `quicsample -client` -> noq server | ❌ `Shut down by transport, 0x5` |
| `quicsample -client -multipath` -> noq server | ❌ same |
| noq client -> `quicsample -server` | ✅ (noq client never advertises the TP) |

**After both commits:**

| quicsample client flags | Observed Address reports | Data exchange |
|---|---|---|
| none (defaults off) | 0 | ✅ |
| `-observed_address_recv` | 1 | ✅ |
| `-observed_address_send` | 0 (noq honors send-only) | ✅ |
| both | 1 | ✅ |
| `-multipath -observed_address_recv` | 2 (one per path) | ✅ |

msquic-to-msquic behaves the same: a server started with `-observed_address_send` reports only to a client that passed `-observed_address_recv`.

`msquiccoretest`: **540 passed, 0 failed** (3 pre-existing skips are the Linux-unsupported storage tests). `TransportParamTest.ObservedAddress` was extended to round-trip all three role values.

## Notes

- Because the frame codepoints no longer fit in 16 bits, `SpinFrame` can no longer generate them, so its OBSERVED_ADDRESS cases become unreachable — the same situation as the existing `ADD_ADDRESS`/`PUNCH_ME_NOW` cases. Fuzzing those would need the loop to draw from a table of known frame types rather than rejection-sample a 16-bit space; left out of this change.
- Rust bindings are updated: `src/rs/settings.rs` gains the two setters, and `linux_bindings.rs` was regenerated with `cargo build --features overwrite`. `win_bindings.rs` cannot be regenerated on Linux, so the identical hunks were applied by hand — the diffs of the two files match line for line and both parse, but it has not been compiled for a Windows target. Verified with `cargo test --features preview-api` (13 passed).
- The C# bindings were not updated; they need their generator re-run. Note they are already missing `MultipathEnabled`.
- Only the Linux clog artifacts were regenerated; Windows builds regenerate theirs as part of the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)