### PR TITLE
Fix MSVC build with -LoggingType stdout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,6 +474,13 @@ if(QUIC_ENABLE_LOGGING)
     elseif (QUIC_LOGGING_TYPE STREQUAL "stdout")
         message(STATUS "Configuring for stdout logging")
         list(APPEND QUIC_COMMON_DEFINES QUIC_EVENTS_STDOUT QUIC_LOGS_STDOUT)
+        if (MSVC)
+            # The stdout trace macros rely on the GNU-style ',##__VA_ARGS__'
+            # comma elision. MSVC's traditional preprocessor leaves a stray
+            # comma behind when the variadic list is empty, so require the
+            # conformant preprocessor here.
+            list(APPEND QUIC_COMMON_FLAGS /Zc:preprocessor)
+        endif()
     endif()
 
 else()


### PR DESCRIPTION
## Problem

`./scripts/build.ps1 -Tls schannel -G "Visual Studio 17 2022" -LoggingType stdout` failed with a flood of compile errors while building `testlib`:

```
src\test\lib\TestHelpers.h(612,9): error C2059: syntax error: ','
src\test\lib\TestHelpers.h(627,9): error C2059: syntax error: ','
...
```

`build.ps1` itself is fine and the CMake configure step succeeds. What was broken is the combination of **MSVC + stdout logging**.

## Root cause

The stdout trace macros in `src/inc/quic_trace.h` rely on the GNU-style `,##__VA_ARGS__` comma elision (drop the preceding comma when the variadic list is empty). MSVC''s traditional preprocessor — the default — does not honor it and leaves the comma behind.

```c
QuicTraceLogInfo(TestHookRegister, "[test][hook] Registering");
```

expands to (verified with `cl /EP`):

```c
clog_stdout(&__head, (("[test][hook] Registering" " [" "TestHookRegister" ":%s:%d]\n")),, "t.c", 22);
//                                                                                     ^^ stray comma
```

Calls that do pass variadic arguments expand correctly, which is why only `testlib` — which contains many zero-argument trace calls — appeared to fail.

## Fix

Request the conformant preprocessor (`/Zc:preprocessor`) for MSVC builds when stdout logging is selected. The flag is scoped to that combination, so the default ETW builds are unaffected.

## Verification

- Before: the command above failed while building `testlib`.
- After: the build runs to completion across all targets (`msquic.dll`, `testlib`, and the tools).
- Ran the resulting `msquicplatformtest.exe` and confirmed traces are emitted to stdout:

```
[ dll] Loaded [WindowsUserLoaded:...\src\platform\platform_winuser.c:58]
[ dll] Processors: (6 active, 6 max), Groups: (1 active, 1 max) [WindowsUserProcessorStateV3:...]
[ dll] Initialized (AvailMem = 39107174400 bytes, TimerResolution = [1, 1000000]) [WindowsUserInitialized2:...]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)