### PR TITLE
Track the datagram send state last indicated to the application

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -2408,6 +2408,22 @@ QuicConnSetConfiguration(
         "[conn][%p] Handshake start",
         Connection);
 
+    //
+    // Re-evaluate the datagram send state now that the connection is started
+    // and owned by the application.
+    //
+    // `Started` is an input to the max send length (QuicDatagramOnSendStateChanged
+    // derives it from QUIC_DPLPMTUD_MIN_MTU until then, and from the path's MTU
+    // afterwards), so it has to be recomputed here regardless. For a server this
+    // is also the first evaluation with an owner to indicate to: the peer's
+    // transport parameters are processed before the listener hands the
+    // connection over, so nothing before this point could reach the application.
+    //
+    // Clients reach this path before any peer transport parameters exist, so
+    // their behaviour is unchanged.
+    //
+    QuicDatagramOnSendStateChanged(&Connection->Datagram);
+
     Status =
         QuicCryptoInitializeTls(
             &Connection->Crypto,

--- a/src/core/datagram.c
+++ b/src/core/datagram.c
@@ -79,6 +79,8 @@ QuicDatagramInitialize(
 {
     Datagram->SendEnabled = TRUE;
     Datagram->MaxSendLength = UINT16_MAX;
+    Datagram->IndicatedSendEnabled = FALSE;
+    Datagram->IndicatedMaxSendLength = 0;
     Datagram->PrioritySendQueueTail = &Datagram->SendQueue;
     Datagram->SendQueueTail = &Datagram->SendQueue;
     CxPlatDispatchLockInitialize(&Datagram->ApiQueueLock);
@@ -283,15 +285,30 @@ QuicDatagramOnSendStateChanged(
         }
     }
 
-    if (SendEnabled == Datagram->SendEnabled) {
-        if (!SendEnabled || NewMaxSendLength == Datagram->MaxSendLength) {
-            return;
-        }
+    //
+    // Whether the live state moved, and whether the application's view of it is
+    // stale, are separate questions. They diverge when the state changes with no
+    // external owner to indicate to, which is the normal case for a server: the
+    // peer's transport parameters are processed before the listener hands the
+    // connection over. Comparing only against the live state there would leave
+    // the change looking already reported, and the application would never learn
+    // that datagrams are sendable.
+    //
+    const BOOLEAN StateChanged =
+        SendEnabled != Datagram->SendEnabled ||
+        (SendEnabled && NewMaxSendLength != Datagram->MaxSendLength);
+    const BOOLEAN IndicationNeeded =
+        Connection->State.ExternalOwner &&
+        (SendEnabled != Datagram->IndicatedSendEnabled ||
+         (SendEnabled && NewMaxSendLength != Datagram->IndicatedMaxSendLength));
+
+    if (!StateChanged && !IndicationNeeded) {
+        return;
     }
 
     Datagram->MaxSendLength = NewMaxSendLength;
 
-    if (Connection->State.ExternalOwner) {
+    if (IndicationNeeded) {
         QUIC_CONNECTION_EVENT Event;
         Event.Type = QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED;
         Event.DATAGRAM_STATE_CHANGED.SendEnabled = SendEnabled;
@@ -304,15 +321,20 @@ QuicDatagramOnSendStateChanged(
             Event.DATAGRAM_STATE_CHANGED.SendEnabled,
             Event.DATAGRAM_STATE_CHANGED.MaxSendLength);
         (void)QuicConnIndicateEvent(Connection, &Event);
+
+        Datagram->IndicatedSendEnabled = SendEnabled;
+        Datagram->IndicatedMaxSendLength = NewMaxSendLength;
     }
 
-    if (!SendEnabled) {
-        QuicDatagramSendShutdown(Datagram);
-    } else {
-        if (!Datagram->SendEnabled) {
-            Datagram->SendEnabled = TRUE; // This can happen for 0-RTT connections that didn't previously support Datagrams
+    if (StateChanged) {
+        if (!SendEnabled) {
+            QuicDatagramSendShutdown(Datagram);
+        } else {
+            if (!Datagram->SendEnabled) {
+                Datagram->SendEnabled = TRUE; // This can happen for 0-RTT connections that didn't previously support Datagrams
+            }
+            QuicDatagramOnMaxSendLengthChanged(Datagram);
         }
-        QuicDatagramOnMaxSendLengthChanged(Datagram);
     }
 
     QuicDatagramValidate(Datagram);

--- a/src/core/datagram.h
+++ b/src/core/datagram.h
@@ -33,10 +33,27 @@ typedef struct QUIC_DATAGRAM {
     uint16_t MaxSendLength;
 
     //
+    // The send state last indicated to the application, which is not always the
+    // live state above. The send state can change while the connection has no
+    // external owner to indicate to — a server connection processes the peer's
+    // transport parameters before the listener hands it to the application —
+    // and such a change must not be mistaken for one that was already reported,
+    // or the application is never told at all.
+    //
+    uint16_t IndicatedMaxSendLength;
+
+    //
     // Indicates that datagrams are allowed by the peer and can be queued up to
     // send.
     //
     BOOLEAN SendEnabled : 1;
+
+    //
+    // The `SendEnabled` last indicated to the application. Starts FALSE: until
+    // an indication is made the application has been told nothing, and assumes
+    // datagrams are not sendable.
+    //
+    BOOLEAN IndicatedSendEnabled : 1;
 
 } QUIC_DATAGRAM;
 


### PR DESCRIPTION
A server application never receives `QUIC_CONNECTION_EVENT_DATAGRAM_STATE_CHANGED` unless path MTU discovery happens to change the max send length. On a path where it does not, the application waits forever and never sends a datagram — while receiving them perfectly well.

## Why

`QuicDatagramOnSendStateChanged` committed the new state unconditionally, but indicated it only to an owner:

```c
    if (SendEnabled == Datagram->SendEnabled) {
        if (!SendEnabled || NewMaxSendLength == Datagram->MaxSendLength) {
            return;                                   // "already reported"
        }
    }

    Datagram->MaxSendLength = NewMaxSendLength;        // recorded regardless

    if (Connection->State.ExternalOwner) {             // reported only if owned
        ... QuicConnIndicateEvent(DATAGRAM_STATE_CHANGED) ...
    }
```

On a server the peer's transport parameters are processed **before** the listener hands the connection to the application. That evaluation runs unowned: it records a state nobody can be told about, and from then on every evaluation compares equal and returns early. The change has been accounted for as if it were reported.

The only rescue is a length that differs, which in practice means MTU discovery moving `Path->Mtu`. Hence: works on one network, hangs on another, same build.

## Fix

Whether the live state moved and whether the application's view is stale are separate questions, so `QUIC_DATAGRAM` now tracks both. The early return consults the indicated state; the indicated state is updated only where an indication is actually made; and the side effects of a real state change — send shutdown, max-length requeue — stay tied to the live state.

`IndicatedSendEnabled` starts `FALSE`, because until an indication is made the application has been told nothing and assumes datagrams are unsendable.

That alone cannot deliver the missing indication, since nothing re-evaluates once a server connection gains its owner. `QuicConnSetConfiguration` now does, immediately after `State.Started` is set — which it must in any case, since `Started` is an input to the max send length (`QUIC_DPLPMTUD_MIN_MTU` before it, `Path->Mtu` after). Clients reach that path before any peer transport parameters exist, so their behaviour is unchanged.

The two parts compose: the re-evaluation guarantees an evaluation with an owner present, and the split guarantees it is not swallowed even when the computed values happen to be unchanged.

## Behaviour

- Peer supports datagrams: the application is told once, at `SetConfiguration` on a server, as before on a client.
- Peer does not: live state goes disabled while unowned; `IndicatedSendEnabled` is already `FALSE`, so nothing is indicated — matching what the application already assumes, with no spurious event.
- `QuicDatagramValidate`'s `!SendEnabled ⇒ MaxSendLength == 0` invariant holds on every path.

`QUIC_DATAGRAM` is internal to core, so the two added fields are not an API or ABI change.

## How it turned up

A MASQUE relay stalled for one client host but not another, against the same proxy and the same build. The proxy's h3 layer reported `Datagrams are not available` for **every** connection from the affected host, while datagrams in the other direction flowed fine. Tracing `DATAGRAM_STATE_CHANGED` showed it firing only alongside MTU discovery on the working host, and never on the failing one.

Verified by compiling `src/core` — `connection.c` and `datagram.c` rebuilt clean, no new warnings. Not covered by a test here: reproducing it needs a server on a path whose MTU never changes.

## Note

The early return and the unconditional commit both look like upstream code, so this likely affects upstream msquic too — any server application using datagrams is exposed. Worth reporting to microsoft/msquic separately.