### PR TITLE
Bind a bound address on the address that was named

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -7029,9 +7029,9 @@ QuicConnOpenNewPaths(
 // address to be registered. It enforces uniqueness of bound addresses per
 // connection, ensures the per-connection bound-address limit is not exceeded,
 // allocates and stores a new bound-address entry, and creates a corresponding
-// UDP binding using the connection's partition. The local binding is always
-// created with an IPv6 family; if the caller does not specify a port, an
-// ephemeral port is used.
+// UDP binding using the connection's partition. The binding is created on the
+// address the caller named; if the caller does not specify a port, an ephemeral
+// port is used and the address stored on the connection is updated with it.
 //
 _IRQL_requires_max_(PASSIVE_LEVEL)
 static
@@ -7091,9 +7091,8 @@ QuicConnAddBoundAddress(
 
     QUIC_BOUND_ADDRESS_LIST_ENTRY* Bound =
     //
-    // Construct the local address used for the UDP binding. The family is
-    // always set to IPv6; the port is copied from the caller when specified,
-    // otherwise an ephemeral port is requested by passing zero.
+    // The caller's address is used for the UDP binding as given. A zero port
+    // requests an ephemeral one, which is read back off the binding below.
     //
         (QUIC_BOUND_ADDRESS_LIST_ENTRY*)
         CXPLAT_ALLOC_NONPAGED(
@@ -7112,13 +7111,9 @@ QuicConnAddBoundAddress(
     CxPlatCopyMemory(&Bound->Address, Param, sizeof(QUIC_ADDR));
 
     BOOLEAN PortUnspecified = QuicAddrGetPort(Param) == 0;
-    QUIC_ADDR BindingLocalAddress = {0};
-    QuicAddrSetFamily(&BindingLocalAddress, QUIC_ADDRESS_FAMILY_INET6);
-    QuicAddrSetPort(&BindingLocalAddress,
-        PortUnspecified ? 0 : QuicAddrGetPort(Param));
 
     CXPLAT_UDP_CONFIG UdpConfig = {0};
-    UdpConfig.LocalAddress = &BindingLocalAddress;
+    UdpConfig.LocalAddress = Param;
     UdpConfig.RemoteAddress = NULL;
     UdpConfig.Flags = CXPLAT_SOCKET_FLAG_NONE;
     UdpConfig.InterfaceIndex = 0;
@@ -7151,6 +7146,7 @@ QuicConnAddBoundAddress(
     }
  
     if (PortUnspecified) {
+        QUIC_ADDR BindingLocalAddress = {0};
         QuicBindingGetLocalAddress(Bound->Binding, &BindingLocalAddress);
         QuicAddrSetPort(
             &Bound->Address,


### PR DESCRIPTION
## Description

`QuicConnAddBoundAddress` stored the caller's address on the connection, but created the binding on the IPv6 wildcard with only the port carried over:

```c
    QUIC_ADDR BindingLocalAddress = {0};
    QuicAddrSetFamily(&BindingLocalAddress, QUIC_ADDRESS_FAMILY_INET6);
    QuicAddrSetPort(&BindingLocalAddress,
        PortUnspecified ? 0 : QuicAddrGetPort(Param));

    CXPLAT_UDP_CONFIG UdpConfig = {0};
    UdpConfig.LocalAddress = &BindingLocalAddress;
```

So the socket listened on every local address rather than the one the application named, and the address recorded in `Bound->Address` — the one advertised to the peer in ADD_ADDRESS — was not the address actually bound. On a multi-homed host that means an application cannot choose which interface a bound address belongs to.

Pass the caller's address to `QuicLibraryGetBinding` as given:

```c
    CXPLAT_UDP_CONFIG UdpConfig = {0};
    UdpConfig.LocalAddress = Param;
```

A zero port still requests an ephemeral one, and is still read back off the binding afterwards, so the address recorded on the connection names the port that was really assigned. `BindingLocalAddress` moves into that branch, which is the only place it is now needed.

This is the second half of 55cfd6a, minus the commented-out code.

Two comments that described the old behaviour ("The local binding is always created with an IPv6 family", "The family is always set to IPv6") are updated to match.

## Testing

No new tests. The behaviour is exercised by the existing bound-address tests, which pass either way because they use loopback, where the wildcard binding also receives the traffic. The difference shows on a multi-homed host, which the test environment is not.

- `*Migration*:*Path*` passes in full: 96 tests, including the 54 `ServerMigration` cases that drive `QUIC_PARAM_CONN_ADD_BOUND_ADDRESS`.
- `*Basic*:*Datagram*:*Mtu*` passes in full: 514 tests.
- No compiler warnings.

## Documentation

No documentation impact. `QUIC_PARAM_CONN_ADD_BOUND_ADDRESS` is documented as taking a `QUIC_ADDR` to bind, which is what it now does.
