### PR TITLE
Keep source connection IDs while a shared binding is still in use

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -6746,7 +6746,24 @@ QuicConnProcessPathValidationTimerOperation(
         if (Connection->PathsCount > 1 &&
             Connection->Paths[i].Binding != NULL) {
             if (!Connection->Paths[i].UseBound) {
-                QuicBindingRemoveAllSourceConnectionIDs(Connection->Paths[i].Binding, Connection);
+                //
+                // An unconnected binding is matched on local port alone, so
+                // paths to different remote addresses can share one. The source
+                // connection IDs registered on it belong to the connection, not
+                // to this path, and the paths still using the binding are still
+                // reached through them. Only withdraw them once no other path
+                // holds the same binding, or those paths stop receiving.
+                //
+                BOOLEAN IsCommonBinding = FALSE;
+                for (uint8_t j = 0; j < Connection->PathsCount; ++j) {
+                    if (i != j && Connection->Paths[i].Binding == Connection->Paths[j].Binding) {
+                        IsCommonBinding = TRUE;
+                        break;
+                    }
+                }
+                if (!IsCommonBinding) {
+                    QuicBindingRemoveAllSourceConnectionIDs(Connection->Paths[i].Binding, Connection);
+                }
             }
             QuicLibraryReleaseBinding(Connection->Paths[i].Binding);
             Connection->Paths[i].Binding = NULL;
@@ -6924,6 +6941,22 @@ QuicConnOpenNewPath(
 
     Path->Binding = NewBinding;
 
+    //
+    // QuicLibraryGetBinding hands back an existing binding whenever one matches,
+    // so this path may well have joined a binding another path of this same
+    // connection is already on. That is the normal case for an unconnected
+    // socket, which is matched on local port alone and therefore shared across
+    // paths to different remote addresses. Whether the connection's source
+    // connection IDs still have to be registered below depends on which it was.
+    //
+    BOOLEAN ReallyNewBinding = TRUE;
+    for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
+        if (Path != &Connection->Paths[i] && Connection->Paths[i].Binding == NewBinding) {
+            ReallyNewBinding = FALSE;
+            break;
+        }
+    }
+
     QuicBindingGetLocalAddress(
         Path->Binding,
         &Path->Route.LocalAddress);
@@ -6960,26 +6993,34 @@ QuicConnOpenNewPath(
         Path->PathID = Connection->Paths[0].PathID;
     }
 
-    if (!Connection->State.ShareBinding) {
-        QUIC_CID_SLIST_ENTRY* SourceCid = QuicCidNewNullSource(Path->PathID);
-        if (SourceCid == NULL) {
-            Status = QUIC_STATUS_OUT_OF_MEMORY;
-            goto Error;
-        }
+    //
+    // Registering the source connection IDs is what makes the binding deliver
+    // this connection's packets, and it is per binding, not per path. A binding
+    // inherited from another path of this connection already carries them, so
+    // doing it again would either add a second null source CID for the same
+    // connection or re-register the ones already there.
+    //
+    if (ReallyNewBinding) {
+        if (!Connection->State.ShareBinding) {
+            QUIC_CID_SLIST_ENTRY* SourceCid = QuicCidNewNullSource(Path->PathID);
+            if (SourceCid == NULL) {
+                Status = QUIC_STATUS_OUT_OF_MEMORY;
+                goto Error;
+            }
 
-        Path->PathID->NextSourceCidSequenceNumber++;
-        QuicPathIDAddSourceCID(Path->PathID, SourceCid, FALSE);
+            Path->PathID->NextSourceCidSequenceNumber++;
+            QuicPathIDAddSourceCID(Path->PathID, SourceCid, FALSE);
 
-        if (!QuicBindingAddSourceConnectionID(NewBinding, SourceCid)) {
-            Status = QUIC_STATUS_OUT_OF_MEMORY;
-            goto Error;
-        }
-    } else {
-        if (!QuicBindingAddAllSourceConnectionIDs(NewBinding, Connection)) {
-            QuicPathIDSetGenerateNewSourceCids(&Connection->PathIDs, TRUE);
+            if (!QuicBindingAddSourceConnectionID(NewBinding, SourceCid)) {
+                Status = QUIC_STATUS_OUT_OF_MEMORY;
+                goto Error;
+            }
+        } else {
+            if (!QuicBindingAddAllSourceConnectionIDs(NewBinding, Connection)) {
+                QuicPathIDSetGenerateNewSourceCids(&Connection->PathIDs, TRUE);
+            }
         }
     }
-
 
     QuicTraceEvent(
         ConnLocalAddrAdded,

--- a/src/core/lookup.c
+++ b/src/core/lookup.c
@@ -550,7 +550,7 @@ QuicLookupInsertLocalCid(
         LookupCidInsert,
         "[look][%p] Insert Conn=%p Hash=%u",
         Lookup,
-        SourceCid->Connection,
+        SourceCid->PathID->Connection,
         Hash);
 #endif
 
@@ -635,7 +635,7 @@ QuicLookupRemoveLocalCidInt(
         LookupCidRemoved,
         "[look][%p] Remove Conn=%p",
         Lookup,
-        SourceCid->Connection);
+        SourceCid->PathID->Connection);
 #endif
 
     if (Lookup->PartitionCount == 0) {


### PR DESCRIPTION
## Description

An unconnected binding is matched on local port alone, so a connection's paths to different remote addresses share one. The source connection IDs registered on that binding are what makes it deliver the connection's packets, and they belong to the connection rather than to any one path.

Both sides of that registration assumed a binding per path.

### Registration

`QuicConnOpenNewPath` registered the source connection IDs on every binding it obtained. `QuicLibraryGetBinding` hands back an existing binding whenever one matches, so that included a binding another path of the same connection was already on. Depending on `ShareBinding`, that either added a second null source CID for the connection or re-registered the ones already there.

### Withdrawal — the reachability bug

`QuicConnProcessPathValidationTimerOperation` withdrew them whenever it abandoned a path:

```c
            if (!Connection->Paths[i].UseBound) {
                QuicBindingRemoveAllSourceConnectionIDs(Connection->Paths[i].Binding, Connection);
            }
            QuicLibraryReleaseBinding(Connection->Paths[i].Binding);
```

without checking whether another path still held the same binding. `QuicLibraryReleaseBinding` is refcounted and correctly kept the binding alive for those paths, but the binding had nothing left to match their packets against, so they silently stopped receiving. One unreachable path taking the others down with it.

### Fix

Register only when the binding was not already one of this connection's, and withdraw only when no other path still holds it.

### Also

Two DEBUG-only trace arguments in `lookup.c` still reached for `SourceCid->Connection`, which `QUIC_CID_SLIST_ENTRY` does not have — the surrounding code already goes through `SourceCid->PathID->Connection`. They only compile under `#if DEBUG` with logging enabled, which is why they survived.

## Testing

No new tests. Reaching the withdrawal path means driving a path to validation timeout while another path shares its binding, which needs the packet-drop helpers in `PathTest.cpp` (`PathProbeHelper` and friends) rather than the plain connect-and-check shape the unconnected socket tests use. Filed as follow-up work.

- `*UnconnectedSocket*:*Path*:*Migration*:*ConnectionParam*` passes in full: 104 tests.
- `*Basic*:*Datagram*` passes in full: 501 tests.
- No compiler warnings.

## Documentation

No documentation impact. The behaviour described in `docs/Settings.md` for `QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET` is what this restores, not something it changes.
