### PR TITLE
Fix the QTIP failures from bindings with no remote address

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1660,9 +1660,12 @@ QuicConnStart(
 
         if (Connection->Settings.QTIPEnabled) {
             //
-            // QTIP carries QUIC over a TCP connection, which the raw datapath
-            // cannot establish without a destination. An unconnected socket
-            // deliberately has none, so the two cannot be combined.
+            // The raw datapath reads a socket with no remote address as a
+            // server listener, and requires a wildcard local address of one
+            // (see RawSocketCreateUdp). An unconnected socket has neither: no
+            // remote address by definition, and a specific local address by
+            // requirement. Without QTIP that only costs the raw datapath, since
+            // the socket falls back to an OS one; with it there is no fallback.
             //
             Status = QUIC_STATUS_INVALID_STATE;
             QuicTraceEvent(
@@ -6894,9 +6897,12 @@ QuicConnOpenNewPath(
 
         if (Connection->Settings.QTIPEnabled) {
             //
-            // QTIP carries QUIC over a TCP connection, which the raw datapath
-            // cannot establish without a destination. An unconnected socket
-            // deliberately has none, so the two cannot be combined.
+            // The raw datapath reads a socket with no remote address as a
+            // server listener, and requires a wildcard local address of one
+            // (see RawSocketCreateUdp). An unconnected socket has neither: no
+            // remote address by definition, and a specific local address by
+            // requirement. Without QTIP that only costs the raw datapath, since
+            // the socket falls back to an OS one; with it there is no fallback.
             //
             Status = QUIC_STATUS_INVALID_STATE;
             QuicTraceEvent(
@@ -7222,8 +7228,27 @@ QuicConnAddBoundAddress(
 
     BOOLEAN PortUnspecified = QuicAddrGetPort(Param) == 0;
 
+    //
+    // The binding carries no remote address, which the raw datapath reads as a
+    // server listener and then requires a wildcard local address of (see
+    // RawSocketCreateUdp). Under QTIP there is no falling back to an OS socket,
+    // so bind the wildcard and keep only the port, as this did before it learnt
+    // to bind the address it was given. The address the peer is told about is
+    // still the one the caller named; what is lost is the choice of interface
+    // to receive on, which QTIP could not honour anyway.
+    //
+    QUIC_ADDR WildcardAddress = {0};
+    if (Connection->Settings.QTIPEnabled) {
+        QuicAddrSetFamily(&WildcardAddress, QUIC_ADDRESS_FAMILY_INET6);
+        QuicAddrSetPort(&WildcardAddress, QuicAddrGetPort(Param));
+        QuicTraceLogConnInfo(
+            BoundAddressWildcardForQtip,
+            Connection,
+            "Binding a bound address on the wildcard, as QTIP requires");
+    }
+
     CXPLAT_UDP_CONFIG UdpConfig = {0};
-    UdpConfig.LocalAddress = Param;
+    UdpConfig.LocalAddress = Connection->Settings.QTIPEnabled ? &WildcardAddress : Param;
     UdpConfig.RemoteAddress = NULL;
     UdpConfig.Flags = CXPLAT_SOCKET_FLAG_NONE;
     UdpConfig.InterfaceIndex = 0;

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -1658,6 +1658,21 @@ QuicConnStart(
             goto Exit;
         }
 
+        if (Connection->Settings.QTIPEnabled) {
+            //
+            // QTIP carries QUIC over a TCP connection, which the raw datapath
+            // cannot establish without a destination. An unconnected socket
+            // deliberately has none, so the two cannot be combined.
+            //
+            Status = QUIC_STATUS_INVALID_STATE;
+            QuicTraceEvent(
+                ConnError,
+                "[conn][%p] ERROR, %s.",
+                Connection,
+                "Unconnected socket is not supported with QTIP");
+            goto Exit;
+        }
+
         if (!Connection->State.LocalAddressSet ||
             QuicAddrIsWildCard(&Path->Route.LocalAddress)) {
             //
@@ -6874,6 +6889,21 @@ QuicConnOpenNewPath(
                 "[conn][%p] ERROR, %s.",
                 Connection,
                 "Unconnected socket requires a shared binding");
+            goto Error;
+        }
+
+        if (Connection->Settings.QTIPEnabled) {
+            //
+            // QTIP carries QUIC over a TCP connection, which the raw datapath
+            // cannot establish without a destination. An unconnected socket
+            // deliberately has none, so the two cannot be combined.
+            //
+            Status = QUIC_STATUS_INVALID_STATE;
+            QuicTraceEvent(
+                ConnError,
+                "[conn][%p] ERROR, %s.",
+                Connection,
+                "Unconnected socket is not supported with QTIP");
             goto Error;
         }
 

--- a/src/generated/linux/connection.c.clog.h
+++ b/src/generated/linux/connection.c.clog.h
@@ -777,6 +777,24 @@ tracepoint(CLOG_CONNECTION_C, UpdatePeerPacketTolerance , arg1, arg3);\
 
 #endif
 
+/*----------------------------------------------------------
+// Decoder Ring for BoundAddressWildcardForQtip
+// [conn][%p] Binding a bound address on the wildcard, as QTIP requires
+// QuicTraceLogConnInfo(
+            BoundAddressWildcardForQtip,
+            Connection,
+            "Binding a bound address on the wildcard, as QTIP requires");
+// arg1 = arg1 = Connection = arg1
+----------------------------------------------------------*/
+#ifndef _clog_3_ARGS_TRACE_BoundAddressWildcardForQtip
+#define _clog_3_ARGS_TRACE_BoundAddressWildcardForQtip(uniqueId, arg1, encoded_arg_string)\
+tracepoint(CLOG_CONNECTION_C, BoundAddressWildcardForQtip , arg1);\
+
+#endif
+
+
+
+
 
 
 

--- a/src/generated/linux/connection.c.clog.h.lttng.h
+++ b/src/generated/linux/connection.c.clog.h.lttng.h
@@ -834,6 +834,26 @@ TRACEPOINT_EVENT(CLOG_CONNECTION_C, UpdatePeerPacketTolerance,
 )
 
 
+/*----------------------------------------------------------
+// Decoder Ring for BoundAddressWildcardForQtip
+// [conn][%p] Binding a bound address on the wildcard, as QTIP requires
+// QuicTraceLogConnInfo(
+            BoundAddressWildcardForQtip,
+            Connection,
+            "Binding a bound address on the wildcard, as QTIP requires");
+// arg1 = arg1 = Connection = arg1
+----------------------------------------------------------*/
+TRACEPOINT_EVENT(CLOG_CONNECTION_C, BoundAddressWildcardForQtip,
+    TP_ARGS(
+        const void *, arg1), 
+    TP_FIELDS(
+        ctf_integer_hex(uint64_t, arg1, (uint64_t)arg1)
+    )
+)
+
+
+
+
 
 /*----------------------------------------------------------
 // Decoder Ring for UpdateShareBinding

--- a/src/test/lib/BasicTest.cpp
+++ b/src/test/lib/BasicTest.cpp
@@ -350,6 +350,25 @@ void QuicTestAddrFunctions(const FamilyArgs& Params)
 
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 
+//
+// QTIP carries QUIC over a TCP connection, which the raw datapath cannot
+// establish without a destination, so an unconnected socket is rejected there.
+// The tests below are about what the parameter does when it is available, so
+// they have nothing to check under QTIP.
+//
+static bool QuicTestUnconnectedSocketUnavailable(_In_ MsQuicRegistration& Registration)
+{
+    MsQuicConnection Connection(Registration);
+    if (QUIC_FAILED(Connection.GetInitStatus())) {
+        return false;
+    }
+    MsQuicSettings Settings;
+    if (QUIC_FAILED(Connection.GetSettings(&Settings))) {
+        return false;
+    }
+    return Settings.QTIPEnabled != 0;
+}
+
 void QuicTestConnectUnconnectedSocket(const FamilyArgs& Params)
 {
     const int Family = Params.Family;
@@ -358,6 +377,10 @@ void QuicTestConnectUnconnectedSocket(const FamilyArgs& Params)
 
     MsQuicRegistration Registration(true);
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
+
+    if (QuicTestUnconnectedSocketUnavailable(Registration)) {
+        return;
+    }
 
     MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", ServerSelfSignedCredConfig);
     TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
@@ -439,6 +462,10 @@ void QuicTestUnconnectedSocketRequirements()
     MsQuicRegistration Registration(true);
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
 
+    if (QuicTestUnconnectedSocketUnavailable(Registration)) {
+        return;
+    }
+
     MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", ServerSelfSignedCredConfig);
     TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
 
@@ -511,6 +538,10 @@ void QuicTestUnconnectedSocketAddPathBeforeStart(const FamilyArgs& Params)
 
     MsQuicRegistration Registration(true);
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
+
+    if (QuicTestUnconnectedSocketUnavailable(Registration)) {
+        return;
+    }
 
     MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", ServerSelfSignedCredConfig);
     TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
@@ -597,6 +628,10 @@ void QuicTestUnconnectedSocketAddPathAfterStart(const FamilyArgs& Params)
 
     MsQuicRegistration Registration(true);
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
+
+    if (QuicTestUnconnectedSocketUnavailable(Registration)) {
+        return;
+    }
 
     MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", ServerSelfSignedCredConfig);
     TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());


### PR DESCRIPTION
## Description

Fixes all 50 test failures in the Windows BVT jobs that run with QTIP. The Windows jobs without it pass, so this is specific to the QTIP configuration rather than to Windows.

Two groups of tests fail, and they turn out to have one cause.

| Tests | Count | Since |
|---|---|---|
| `Migration`, `MigrationShareBinding`, `ServerMigration`, `ServerProbePath` | 44 | #51 |
| `ConnectUnconnectedSocket`, `UnconnectedSocketAddPathBeforeStart`, `UnconnectedSocketAddPathAfterStart` | 6 | #49 and #63 |

### Cause

The raw datapath reads a socket with no remote address as a server listener, and requires a wildcard local address of one — `RawSocketCreateUdp` in `datapath_raw_win.c`:

```c
    if (Config->RemoteAddress) {
        // This CxPlatSocket is part of a client connection.
        Socket->Connected = TRUE;
    } else {
        // This CxPlatSocket is part of a server listener.
        CXPLAT_FRE_ASSERT(Config->LocalAddress != NULL);

        if (!QuicAddrIsWildCard(Config->LocalAddress)) { // For server listeners, the local address MUST be a wildcard address.
            Status = QUIC_STATUS_INVALID_STATE;
            goto Error;
        }
        Socket->Wildcard = TRUE;
    }
```

Two places now ask for a binding with no remote address *and* a specific local address:

- `QuicConnAddBoundAddress`, since #51 taught it to bind the address it was given rather than the wildcard.
- `QuicConnStart` / `QuicConnOpenNewPath` with `QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET`, where a specific local address is a requirement.

Without QTIP this only costs the raw datapath: `datapath_xplat.c` falls back to an OS socket and everything works, which is why the non-QTIP jobs pass. QTIP has no fallback, so the binding fails with `ERROR_INVALID_STATE` (0x8007139F).

It also fails slowly. The failure lands in a retry loop meant for something else:

```c
                BOOLEAN IsServerSocket = !(*NewSocket)->HasFixedRemoteAddress;
                if (IsServerSocket && RequiresQtip) {
                    //
                    // This retry loop is purely for QTIP listener sockets that try to reserve both a UDP/TCP port,
                    // which may run into a port collision for TCP ...
                    //
                    continue;
                }
```

`HasFixedRemoteAddress` is just "a remote address was given", so both cases read as listeners and rebind to fresh ephemeral ports a thousand times before giving up. Half a second per attempt.

From the failure artifact of [run 30607988369](https://github.com/seera-networks/msquic/actions/runs/30607988369):

```
[data][...] Created, local=192.168.1.11:59108, remote=0x   <- specific local, no remote
[sock] Failed to create raw socket, status:-2147019873
   ... 1000 times ...
[bind][...] ERROR, 2147947423, Create datapath binding.
```

### Changes

**Bound addresses fall back to the wildcard under QTIP.** `QuicConnAddBoundAddress` binds `[::]` plus the requested port when QTIP is enabled, as it did before #51. The address recorded on the connection, and advertised to the peer, is still the one the caller named. What is lost is the choice of which interface to receive on — which is what #51 added, and which QTIP could not honour anyway. Chosen over rejecting the call so that server migration keeps working under QTIP.

**Unconnected sockets are rejected under QTIP.** There is no equivalent fallback here: the whole point of the parameter is a specific local address, so binding the wildcard would defeat it. `Connection->Settings.QTIPEnabled` is checked alongside the two requirements already enforced, in `QuicConnStart` and `QuicConnOpenNewPath`, returning `QUIC_STATUS_INVALID_STATE` with the same `ConnError` trace shape as its neighbours. Rejected up front an attempt takes 26ms rather than 657ms, and says why.

The four tests covering the parameter skip when QTIP is configured, read off the connection with `GetSettings`. `PathTest.cpp` already branches on the same setting for the same kind of reason. `testlib` also builds for kernel mode, where gtest is not available, so this is a plain early return rather than `GTEST_SKIP()`, matching `PathTest.cpp`.

## Testing

| Condition | Result |
|---|---|
| QTIP off: `*Migration*:*Path*:*UnconnectedSocket*:*Basic*:*ConnectionParam*` | 498 tests pass |
| QTIP on (`--useQTIP`): `*UnconnectedSocket*` | 7 tests pass, skipped in 0ms |
| QTIP on, with the skip disabled | fails as expected, confirming the new check is what rejects it |

No compiler warnings.

**The bound address half cannot be verified locally.** Linux has no XDP, so `--useQTIP` fails everything regardless — 100 failures both with and without this change. Only the Windows CI exercises it. What is verified locally is that the non-QTIP path is untouched.

Coverage is unaffected either way. Of the Windows BVT jobs, five run with `-UseQtip` and are the ones failing; the other eleven do not, pass today, and keep covering both behaviours after this change. The Linux jobs do not use QTIP either.

## Documentation

`docs/Settings.md` is not updated. The restriction belongs to the raw datapath rather than to either parameter, and `QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET` is a preview feature; say the word if it should be written down there too.
