### PR TITLE
Arm the path validation timer when a validation starts

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -7050,6 +7050,13 @@ QuicConnOpenNewPath(
         Path->PathValidationStartTime = CxPlatTimeUs64();
 
         CxPlatRandom(sizeof(Path->Challenge), Path->Challenge);
+
+        //
+        // Starting a validation is not enough on its own: without the timer
+        // there is nothing to notice that it never completed, and a path whose
+        // peer never answers stays on the connection for good.
+        //
+        QuicConnPathValidationTimerUpdate(Connection);
     }
 
     Status = QUIC_STATUS_SUCCESS;

--- a/src/core/pathid.c
+++ b/src/core/pathid.c
@@ -773,6 +773,15 @@ QuicPathIDAssignCids(
         Assigned = TRUE;
     }
 
+    if (Assigned) {
+        //
+        // Starting a validation is not enough on its own: without the timer
+        // there is nothing to notice that it never completed, and a path whose
+        // peer never answers stays on the connection for good.
+        //
+        QuicConnPathValidationTimerUpdate(PathID->Connection);
+    }
+
     return Assigned;
 }
 

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -160,6 +160,7 @@ void QuicTestConnectUnconnectedSocket(const FamilyArgs& Params);
 void QuicTestUnconnectedSocketRequirements();
 void QuicTestUnconnectedSocketAddPathBeforeStart(const FamilyArgs& Params);
 void QuicTestUnconnectedSocketAddPathAfterStart(const FamilyArgs& Params);
+void QuicTestSharedBindingPathRemoval(const FamilyArgs& Params);
 #endif
 
 //

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -1080,6 +1080,15 @@ TEST_P(WithFamilyArgs, UnconnectedSocketAddPathAfterStart) {
     }
 }
 
+TEST_P(WithFamilyArgs, SharedBindingPathRemoval) {
+    TestLoggerT<ParamType> Logger("QuicTestSharedBindingPathRemoval", GetParam());
+    if (TestingKernelMode) {
+        ASSERT_TRUE(InvokeKernelTest(FUNC(QuicTestSharedBindingPathRemoval), GetParam()));
+    } else {
+        QuicTestSharedBindingPathRemoval(GetParam());
+    }
+}
+
 TEST(Basic, UnconnectedSocketRequirements) {
     TestLogger Logger("QuicTestUnconnectedSocketRequirements");
     if (TestingKernelMode) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -524,6 +524,7 @@ ExecuteTestRequest(
     RegisterTestFunction(QuicTestUnconnectedSocketRequirements);
     RegisterTestFunction(QuicTestUnconnectedSocketAddPathBeforeStart);
     RegisterTestFunction(QuicTestUnconnectedSocketAddPathAfterStart);
+    RegisterTestFunction(QuicTestSharedBindingPathRemoval);
 #endif
     RegisterTestFunction(QuicTestConnect_Connect);
 #ifndef QUIC_DISABLE_RESUMPTION

--- a/src/test/lib/BasicTest.cpp
+++ b/src/test/lib/BasicTest.cpp
@@ -350,6 +350,25 @@ void QuicTestAddrFunctions(const FamilyArgs& Params)
 
 #ifdef QUIC_API_ENABLE_PREVIEW_FEATURES
 
+//
+// QTIP carries QUIC over a TCP connection through the raw datapath, which
+// refuses a socket with no remote address unless its local address is the
+// wildcard. An unconnected socket has neither, and under QTIP there is no
+// falling back to an OS socket, so the tests below have nothing to check.
+//
+static bool QuicTestUnconnectedSocketUnavailable(_In_ MsQuicRegistration& Registration)
+{
+    MsQuicConnection Connection(Registration);
+    if (QUIC_FAILED(Connection.GetInitStatus())) {
+        return false;
+    }
+    MsQuicSettings Settings;
+    if (QUIC_FAILED(Connection.GetSettings(&Settings))) {
+        return false;
+    }
+    return Settings.QTIPEnabled != 0;
+}
+
 void QuicTestConnectUnconnectedSocket(const FamilyArgs& Params)
 {
     const int Family = Params.Family;
@@ -358,6 +377,10 @@ void QuicTestConnectUnconnectedSocket(const FamilyArgs& Params)
 
     MsQuicRegistration Registration(true);
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
+
+    if (QuicTestUnconnectedSocketUnavailable(Registration)) {
+        return;
+    }
 
     MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", ServerSelfSignedCredConfig);
     TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
@@ -439,6 +462,10 @@ void QuicTestUnconnectedSocketRequirements()
     MsQuicRegistration Registration(true);
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
 
+    if (QuicTestUnconnectedSocketUnavailable(Registration)) {
+        return;
+    }
+
     MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", ServerSelfSignedCredConfig);
     TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
 
@@ -511,6 +538,10 @@ void QuicTestUnconnectedSocketAddPathBeforeStart(const FamilyArgs& Params)
 
     MsQuicRegistration Registration(true);
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
+
+    if (QuicTestUnconnectedSocketUnavailable(Registration)) {
+        return;
+    }
 
     MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", ServerSelfSignedCredConfig);
     TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
@@ -598,6 +629,10 @@ void QuicTestUnconnectedSocketAddPathAfterStart(const FamilyArgs& Params)
     MsQuicRegistration Registration(true);
     TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
 
+    if (QuicTestUnconnectedSocketUnavailable(Registration)) {
+        return;
+    }
+
     MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", ServerSelfSignedCredConfig);
     TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
 
@@ -683,6 +718,157 @@ void QuicTestUnconnectedSocketAddPathAfterStart(const FamilyArgs& Params)
         QuicAddr StillClientAddr;
         TEST_QUIC_SUCCEEDED(Connection.GetLocalAddr(StillClientAddr));
         TEST_EQUAL(ClientAddr.GetPort(), StillClientAddr.GetPort());
+    }
+}
+
+struct SharedBindingPathContext {
+    CxPlatEvent ServerConnectedEvent;
+    CxPlatEvent ClientPeerStreamEvent;
+    MsQuicConnection* ServerConnection {nullptr};
+
+    static QUIC_STATUS QUIC_API ServerConnCallback(_In_ MsQuicConnection* Conn, _In_opt_ void* Context, _Inout_ QUIC_CONNECTION_EVENT* Event) {
+        auto Ctx = (SharedBindingPathContext*)Context;
+        if (Event->Type == QUIC_CONNECTION_EVENT_CONNECTED) {
+            Ctx->ServerConnection = Conn;
+            Ctx->ServerConnectedEvent.Set();
+        } else if (Event->Type == QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE) {
+            Ctx->ServerConnection = nullptr;
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+
+    static QUIC_STATUS QUIC_API ClientConnCallback(_In_ MsQuicConnection*, _In_opt_ void* Context, _Inout_ QUIC_CONNECTION_EVENT* Event) {
+        auto Ctx = (SharedBindingPathContext*)Context;
+        if (Event->Type == QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED) {
+            MsQuic->StreamClose(Event->PEER_STREAM_STARTED.Stream);
+            Ctx->ClientPeerStreamEvent.Set();
+        }
+        return QUIC_STATUS_SUCCESS;
+    }
+};
+
+//
+// A connection whose socket is left unconnected reaches several remote
+// addresses through one binding, so its paths share it. The source connection
+// IDs registered on that binding are what makes it deliver the connection's
+// packets, and they belong to the connection rather than to any one path.
+// Abandoning one path must therefore leave the others receiving.
+//
+void QuicTestSharedBindingPathRemoval(const FamilyArgs& Params)
+{
+    const int Family = Params.Family;
+    const QUIC_ADDRESS_FAMILY QuicAddrFamily =
+        (Family == 4) ? QUIC_ADDRESS_FAMILY_INET : QUIC_ADDRESS_FAMILY_INET6;
+
+    MsQuicRegistration Registration(true);
+    TEST_QUIC_SUCCEEDED(Registration.GetInitStatus());
+
+    if (QuicTestUnconnectedSocketUnavailable(Registration)) {
+        return;
+    }
+
+    MsQuicSettings Settings;
+    Settings.SetPeerBidiStreamCount(4).SetPeerUnidiStreamCount(4);
+    MsQuicConfiguration ServerConfiguration(Registration, "MsQuicTest", Settings, ServerSelfSignedCredConfig);
+    TEST_QUIC_SUCCEEDED(ServerConfiguration.GetInitStatus());
+
+    MsQuicConfiguration ClientConfiguration(Registration, "MsQuicTest", Settings, MsQuicCredentialConfig());
+    TEST_QUIC_SUCCEEDED(ClientConfiguration.GetInitStatus());
+
+    SharedBindingPathContext Context;
+
+    //
+    // The path that survives is the connection's first, to the first server.
+    // The path that is abandoned goes to the second, so that dropping traffic
+    // by port separates the two.
+    //
+    MsQuicAutoAcceptListener Listener1(Registration, ServerConfiguration, SharedBindingPathContext::ServerConnCallback, &Context);
+    TEST_QUIC_SUCCEEDED(Listener1.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Listener1.Start("MsQuicTest"));
+    QuicAddr Server1Addr;
+    TEST_QUIC_SUCCEEDED(Listener1.GetLocalAddr(Server1Addr));
+
+    MsQuicAutoAcceptListener Listener2(Registration, ServerConfiguration, MsQuicConnection::NoOpCallback);
+    TEST_QUIC_SUCCEEDED(Listener2.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Listener2.Start("MsQuicTest"));
+    QuicAddr Server2Addr;
+    TEST_QUIC_SUCCEEDED(Listener2.GetLocalAddr(Server2Addr));
+
+    TEST_NOT_EQUAL(Server1Addr.GetPort(), Server2Addr.GetPort());
+
+    QuicAddr LocalAddr(QuicAddrFamily, true);
+    if (UseDuoNic) {
+        QuicAddrSetToDuoNic(&LocalAddr.SockAddr);
+    }
+
+    MsQuicConnection Connection(Registration, CleanUpManual, SharedBindingPathContext::ClientConnCallback, &Context);
+    TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+    TEST_QUIC_SUCCEEDED(Connection.SetShareUdpBinding());
+    TEST_QUIC_SUCCEEDED(Connection.SetUnconnectedUdpSocket());
+    TEST_QUIC_SUCCEEDED(Connection.SetLocalAddr(LocalAddr));
+    TEST_QUIC_SUCCEEDED(
+        Connection.Start(
+            ClientConfiguration,
+            QuicAddrFamily,
+            QUIC_TEST_LOOPBACK_FOR_AF(QuicAddrFamily),
+            Server1Addr.GetPort()));
+    TEST_TRUE(Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
+    TEST_TRUE(Connection.HandshakeComplete);
+    TEST_TRUE(Context.ServerConnectedEvent.WaitTimeout(TestWaitTimeout));
+    TEST_NOT_EQUAL(nullptr, Context.ServerConnection);
+
+    //
+    // Wait for handshake confirmation, so the path below is opened rather than
+    // left pending.
+    //
+    CxPlatSleep(100);
+
+    QuicAddr ClientAddr;
+    TEST_QUIC_SUCCEEDED(Connection.GetLocalAddr(ClientAddr));
+    QuicAddr Peer1Addr;
+    TEST_QUIC_SUCCEEDED(Connection.GetRemoteAddr(Peer1Addr));
+    QuicAddr Peer2Addr = Peer1Addr;
+    Peer2Addr.SetPort(Server2Addr.GetPort());
+
+    //
+    // Drop everything to and from the second server, so the path added below
+    // never validates and is eventually abandoned.
+    //
+    PathProbeHelper ProbeHelper(Server2Addr.GetPort(), 255, 255, TRUE);
+
+    QUIC_PATH_PARAM PathParam = { &ClientAddr.SockAddr, &Peer2Addr.SockAddr };
+    TEST_QUIC_SUCCEEDED(
+        Connection.SetParam(QUIC_PARAM_CONN_ADD_PATH, sizeof(PathParam), &PathParam));
+
+    //
+    // The added path shares the binding, which is the case under test.
+    //
+    QuicAddr StillClientAddr;
+    TEST_QUIC_SUCCEEDED(Connection.GetLocalAddr(StillClientAddr));
+    TEST_EQUAL(ClientAddr.GetPort(), StillClientAddr.GetPort());
+
+    //
+    // Let path validation run out. The timeout is the larger of three PTOs and
+    // six times the initial RTT, so a few seconds covers it on loopback.
+    //
+    CxPlatSleep(5000);
+
+    //
+    // The first path must still be able to receive. A stream opened by the
+    // server only arrives if the binding still carries the connection's source
+    // connection IDs.
+    //
+    TEST_NOT_EQUAL(nullptr, Context.ServerConnection);
+    {
+        MsQuicStream Stream(*Context.ServerConnection, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL, CleanUpManual, MsQuicStream::NoOpCallback);
+        TEST_QUIC_SUCCEEDED(Stream.GetInitStatus());
+        TEST_QUIC_SUCCEEDED(Stream.Start(QUIC_STREAM_START_FLAG_IMMEDIATE));
+
+        uint8_t RawBuffer[16] = {0};
+        QUIC_BUFFER SendBuffer { sizeof(RawBuffer), RawBuffer };
+        TEST_QUIC_SUCCEEDED(Stream.Send(&SendBuffer, 1, QUIC_SEND_FLAG_FIN));
+
+        TEST_TRUE(Context.ClientPeerStreamEvent.WaitTimeout(TestWaitTimeout));
     }
 }
 


### PR DESCRIPTION
Closes #66.

## Description

#66 asked for a test covering the shared-binding check added in #65: abandoning one path of a connection must not withdraw the source connection IDs that the other paths still need. Writing it turned up why that check had gone untested — the code it guards was unreachable.

### The path validation timer was never armed

A path whose peer never answers its `PATH_CHALLENGE` stayed on the connection for good. Two places start a validation and set `PathValidationStartTime` without arming the timer that eventually gives up on it:

- `QuicConnOpenNewPath`, for a path opened by `QUIC_PARAM_CONN_ADD_PATH`.
- `QuicPathIDAssignCids`, for a path that had been waiting on a connection ID and can now be validated.

`QuicConnPathValidationTimerUpdate` was only reached from two places, and neither applies to a path that never hears back:

| Site | Requires |
|---|---|
| `connection.c:5901`, the receive path | a packet on the path in question |
| `connection.c:6790`, end of the timer handler | the timer to have fired once already |

So `QuicConnProcessPathValidationTimerOperation` was never entered for such a path. Verified directly: a probe at the top of that function produces no output for the whole run, including under the existing `Misc.ProbePathFailed`.

Arming it from both sites is the fix. The receive path already does it, and the `PATH_CHALLENGE` retransmit in loss detection continues an existing validation rather than starting one, so those are left alone.

This also makes `Misc.ProbePathFailed` and `ProbePathFailedShareBinding` mean what their names say. They drop every packet on an added path and wait five seconds, but the path was never actually abandoned, so they were only checking that nothing crashed.

### The test

`QuicTestSharedBindingPathRemoval` (`Basic/WithFamilyArgs.SharedBindingPathRemoval`, v4 and v6):

1. A connection with `QUIC_PARAM_CONN_SHARE_UDP_BINDING` and `QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET` connects to a first server.
2. `QUIC_PARAM_CONN_ADD_PATH` adds a path to a second server. The local port is checked to be unchanged, i.e. the binding is shared — which is the case under test.
3. `PathProbeHelper` drops everything to and from the second server, so that path never validates and is abandoned.
4. The server on the surviving path then opens a stream, which has to arrive at the client.

Step 4 is the point. The bug loses reception, not transmission, so it cannot be seen from the client sending; the check has to be something the server originates.

An unconnected socket is required, because paths to different remote addresses only share a binding when the socket is left unconnected. The test therefore skips under QTIP, for the reason the other unconnected socket tests do — see #68, whose helper this duplicates. Whichever of the two lands first, the other should drop its copy.

## Testing

| Condition | Result |
|---|---|
| timer fix + #65's check | passes |
| timer fix, #65's check reverted | **fails** — the client never receives the server's stream |
| without the timer fix | the path is never abandoned, so it passes either way |
| `*Path*:*Migration*:*ProbePath*` | 102 tests pass |
| `*Basic*:*Datagram*:*ConnectionParam*` | 504 tests pass |

No compiler warnings.

## Not covered

The other half of #66, the registration side — `QuicConnOpenNewPath` no longer re-registering source connection IDs on a binding inherited from another path — is still untested. It has no observable difference in behaviour, as #66 noted; checking it would mean inspecting the binding's CID state directly. Leaving the issue's remaining scope out rather than writing a test that does not test it.

## Documentation

No documentation impact.
