### PR TITLE
Fix three multipath path ID bugs

### DIFF
--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -199,6 +199,7 @@ QuicConnAlloc(
         QuicPathIDAddRef(PathID, QUIC_PATHID_REF_PATH);
         Path->PathID = PathID;
         PathID->Path = Path;
+        PathID->Flags.InUse = TRUE;
         QuicCongestionControlInitialize(&PathID->CongestionControl, &Connection->Settings);
 
         Path->DestCid =
@@ -239,6 +240,7 @@ QuicConnAlloc(
         QuicPathIDAddRef(PathID, QUIC_PATHID_REF_PATH);
         Path->PathID = PathID;
         PathID->Path = Path;
+        PathID->Flags.InUse = TRUE;
         QuicCongestionControlInitialize(&PathID->CongestionControl, &Connection->Settings);
 
         Path->DestCid = QuicCidNewRandomDestination();

--- a/src/core/path.c
+++ b/src/core/path.c
@@ -311,7 +311,9 @@ QuicConnGetPathForPacket(
     CXPLAT_DBG_ASSERT(!FatalError);
     if (PathID == NULL) {
         return NULL;
-    }   
+    }
+    BOOLEAN IsRebind = FALSE;
+
     for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
         if (PathID != Connection->Paths[i].PathID ||
             !QuicAddrCompare(
@@ -327,6 +329,20 @@ QuicConnGetPathForPacket(
                 QuicPathIDRelease(PathID, QUIC_PATHID_REF_LOOKUP);
                 return NULL;
             }
+            if (!IsRebind) {
+                //
+                // The packet did not match this path, but it may still be the
+                // same path seen through a NAT that changed its port: same path
+                // ID, same local address, same remote address but for the port.
+                // That is a rebind of an existing path rather than a new one,
+                // and the check below lets it through.
+                //
+                IsRebind =
+                    PathID == Connection->Paths[i].PathID &&
+                    QuicAddrGetFamily(&Packet->Route->RemoteAddress) == QuicAddrGetFamily(&Connection->Paths[i].Route.RemoteAddress)
+                    && QuicAddrCompareIp(&Packet->Route->RemoteAddress, &Connection->Paths[i].Route.RemoteAddress)
+                    && QuicAddrCompare(&Packet->Route->LocalAddress, &Connection->Paths[i].Route.LocalAddress);
+            }
             continue;
         }
         QuicPathIDRelease(PathID, QUIC_PATHID_REF_LOOKUP);
@@ -336,6 +352,19 @@ QuicConnGetPathForPacket(
     if (!((QuicConnIsClient(Connection) && Connection->State.ServerMigrationNegotiated) ||
           (QuicConnIsServer(Connection) && !Connection->State.ServerMigrationNegotiated))) {
         // Client doesn't create a new path.
+        QuicPathIDRelease(PathID, QUIC_PATHID_REF_LOOKUP);
+        return NULL;
+    }
+
+    if (Connection->State.MultipathNegotiated &&
+        PathID->Flags.InUse &&
+        !IsRebind) {
+        //
+        // With multipath a path ID identifies one path, so a path ID that
+        // already has one cannot acquire a second. Reaching here means the
+        // packet carried a path ID in use, from an address that is neither that
+        // path's nor a rebind of it, which is not something to open a path for.
+        //
         QuicPathIDRelease(PathID, QUIC_PATHID_REF_LOOKUP);
         return NULL;
     }
@@ -430,10 +459,17 @@ QuicConnGetPathForPacket(
     QuicPathIDAddRef(PathID, QUIC_PATHID_REF_PATH);
     Path->PathID = PathID;
     PathID->Path = Path;
-    if (Connection->State.MultipathNegotiated) {
-        QuicCongestionControlInitialize(&PathID->CongestionControl, &Connection->Settings);
+    //
+    // Only a path ID being claimed for the first time needs its congestion
+    // control set up. Getting here with one already in use means a rebind, and
+    // the path it rebinds carries on with the state it had built up.
+    //
+    if (!PathID->Flags.InUse) {
+        if (Connection->State.MultipathNegotiated) {
+            QuicCongestionControlInitialize(&PathID->CongestionControl, &Connection->Settings);
+        }
+        PathID->Flags.InUse = TRUE;
     }
-    PathID->Flags.InUse = TRUE;
     QuicCopyRouteInfo(&Path->Route, Packet->Route);
     Path->Route.State = RouteUnresolved;
     Path->Route.Queue = NULL;

--- a/src/core/pathid.c
+++ b/src/core/pathid.c
@@ -792,7 +792,8 @@ QuicPathIDWriteNewConnectionIDFrame(
     _Inout_ QUIC_PACKET_BUILDER* Builder,
     _In_ uint16_t AvailableBufferLength,
     _Inout_ BOOLEAN* HasMoreCidsToSend,
-    _Inout_ BOOLEAN* MaxFrameLimitHit
+    _Inout_ BOOLEAN* MaxFrameLimitHit,
+    _In_ BOOLEAN NoRoom
     )
 {
     QUIC_FRAME_TYPE FrameType =
@@ -809,9 +810,14 @@ QuicPathIDWriteNewConnectionIDFrame(
         if (!SourceCid->CID.NeedsToSend) {
             continue;
         }
-        if (*MaxFrameLimitHit) {
+        //
+        // This CID cannot go in the current packet, but it still wants to be
+        // sent. Saying so is what keeps the send flag raised for the next one;
+        // returning without saying it would drop the CID for good.
+        //
+        if (*MaxFrameLimitHit || NoRoom) {
             *HasMoreCidsToSend = TRUE;
-            return TRUE;
+            return !NoRoom;
         }
 
         QUIC_NEW_CONNECTION_ID_EX Frame = {
@@ -868,7 +874,8 @@ QuicPathIDWriteRetireConnectionIDFrame(
     _Inout_ QUIC_PACKET_BUILDER* Builder,
     _In_ uint16_t AvailableBufferLength,
     _Inout_ BOOLEAN* HasMoreCidsToSend,
-    _Inout_ BOOLEAN* MaxFrameLimitHit
+    _Inout_ BOOLEAN* MaxFrameLimitHit,
+    _In_ BOOLEAN NoRoom
     )
 {
     QUIC_FRAME_TYPE FrameType =
@@ -887,9 +894,14 @@ QuicPathIDWriteRetireConnectionIDFrame(
         }
         CXPLAT_DBG_ASSERT(DestCid->CID.Retired);
 
-        if (*MaxFrameLimitHit) {
+        //
+        // This CID cannot go in the current packet, but it still wants to be
+        // sent. Saying so is what keeps the send flag raised for the next one;
+        // returning without saying it would drop the CID for good.
+        //
+        if (*MaxFrameLimitHit || NoRoom) {
             *HasMoreCidsToSend = TRUE;
-            return TRUE;
+            return !NoRoom;
         }
 
         QUIC_RETIRE_CONNECTION_ID_EX Frame = {

--- a/src/core/pathid.h
+++ b/src/core/pathid.h
@@ -448,7 +448,8 @@ QuicPathIDWriteNewConnectionIDFrame(
     _Inout_ QUIC_PACKET_BUILDER* Builder,
     _In_ uint16_t AvailableBufferLength,
     _Inout_ BOOLEAN* HasMoreCidsToSend,
-    _Inout_ BOOLEAN* MaxFrameLimitHit
+    _Inout_ BOOLEAN* MaxFrameLimitHit,
+    _In_ BOOLEAN NoRoom
     );
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -458,7 +459,8 @@ QuicPathIDWriteRetireConnectionIDFrame(
     _Inout_ QUIC_PACKET_BUILDER* Builder,
     _In_ uint16_t AvailableBufferLength,
     _Inout_ BOOLEAN* HasMoreCidsToSend,
-    _Inout_ BOOLEAN* MaxFrameLimitHit
+    _Inout_ BOOLEAN* MaxFrameLimitHit,
+    _In_ BOOLEAN NoRoom
     );
 
 //

--- a/src/core/pathid_set.c
+++ b/src/core/pathid_set.c
@@ -384,21 +384,24 @@ QuicPathIDSetWriteNewConnectionIDFrame(
     uint8_t PathIDCount = QUIC_ACTIVE_PATH_ID_LIMIT;
     QuicPathIDSetGetPathIDs(PathIDSet, PathIDs, &PathIDCount);
 
-    BOOLEAN HasMoreCidsToSend1 = FALSE;
-    BOOLEAN MaxFrameLimitHit1 = FALSE;
+    //
+    // Every path ID is visited even once the packet can take no more frames, so
+    // that each still gets to report the CIDs it has waiting. Skipping them
+    // instead leaves HasMoreCidsToSend clear, and the caller then clears the
+    // send flag and never comes back for them.
+    //
+    *HasMoreCidsToSend = FALSE;
+    *MaxFrameLimitHit = FALSE;
     for (uint8_t i = 0; i < PathIDCount; i++) {
-        if (!MaxFrameLimitHit1) {
-            HaveRoom = QuicPathIDWriteNewConnectionIDFrame(
-                PathIDs[i],
-                Builder,
-                AvailableBufferLength,
-                &HasMoreCidsToSend1,
-                &MaxFrameLimitHit1);
-        }
+        HaveRoom = QuicPathIDWriteNewConnectionIDFrame(
+            PathIDs[i],
+            Builder,
+            AvailableBufferLength,
+            HasMoreCidsToSend,
+            MaxFrameLimitHit,
+            !HaveRoom);
         QuicPathIDRelease(PathIDs[i], QUIC_PATHID_REF_LOOKUP);
     }
-    *HasMoreCidsToSend = HasMoreCidsToSend1;
-    *MaxFrameLimitHit = MaxFrameLimitHit1;
 
     return HaveRoom;
 }
@@ -418,21 +421,24 @@ QuicPathIDSetWriteRetireConnectionIDFrame(
     uint8_t PathIDCount = QUIC_ACTIVE_PATH_ID_LIMIT;
     QuicPathIDSetGetPathIDs(PathIDSet, PathIDs, &PathIDCount);
 
-    BOOLEAN HasMoreCidsToSend1 = FALSE;
-    BOOLEAN MaxFrameLimitHit1 = FALSE;
+    //
+    // Every path ID is visited even once the packet can take no more frames, so
+    // that each still gets to report the CIDs it has waiting. Skipping them
+    // instead leaves HasMoreCidsToSend clear, and the caller then clears the
+    // send flag and never comes back for them.
+    //
+    *HasMoreCidsToSend = FALSE;
+    *MaxFrameLimitHit = FALSE;
     for (uint8_t i = 0; i < PathIDCount; i++) {
-        if (!MaxFrameLimitHit1) {
-            HaveRoom = QuicPathIDWriteRetireConnectionIDFrame(
-                PathIDs[i],
-                Builder,
-                AvailableBufferLength,
-                &HasMoreCidsToSend1,
-                &MaxFrameLimitHit1);
-        }
+        HaveRoom = QuicPathIDWriteRetireConnectionIDFrame(
+            PathIDs[i],
+            Builder,
+            AvailableBufferLength,
+            HasMoreCidsToSend,
+            MaxFrameLimitHit,
+            !HaveRoom);
         QuicPathIDRelease(PathIDs[i], QUIC_PATHID_REF_LOOKUP);
     }
-    *HasMoreCidsToSend = HasMoreCidsToSend1;
-    *MaxFrameLimitHit = MaxFrameLimitHit1;
 
     return HaveRoom;
 }

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -1907,9 +1907,17 @@ QuicSendFlush(
 
         BOOLEAN WrotePacketFrames = FALSE;
         BOOLEAN FlushBatchedDatagrams = FALSE;
+        //
+        // The excluded flags are sent per path, above, and are re-raised there
+        // when a path could not take one yet. Treating a re-raised one as a
+        // reason to build a packet on the active path would produce a packet
+        // with nothing in it, since the frame belongs to a different path.
+        //
         BOOLEAN SendConnectionControlData =
             (SendFlags & ~(QUIC_CONN_SEND_FLAG_DPLPMTUD |
-                            QUIC_CONN_SEND_FLAG_PATH_CHALLENGE)) != 0;
+                            QUIC_CONN_SEND_FLAG_PATH_CHALLENGE |
+                            QUIC_CONN_SEND_FLAG_PATH_RESPONSE |
+                            QUIC_CONN_SEND_FLAG_PATH_KEEP_ALIVE)) != 0;
         if (SendConnectionControlData) {
             CXPLAT_DBG_ASSERT(QuicSendCanSendFlagsNow(Send));
             if (!QuicPacketBuilderPrepareForControlFrames(


### PR DESCRIPTION
## Description

Three multipath bugs around path IDs, plus a related send-flag fix.

### The initial path's path ID was not marked in use

`QuicConnAlloc` assigns a path ID to `Paths[0]` without setting `PathID->Flags.InUse`. Both changes below read that flag, so the initial path was invisible to them.

### A path ID already in use could acquire a second path

With multipath a path ID identifies one path. `QuicConnGetPathForPacket` would nonetheless open another for a packet that carried a path ID already in use and came from an address that was neither that path's nor a rebind of it.

A NAT that changes only the port *is* such a rebind — same path ID, same local address, same remote address but for the port — and is still let through:

```c
                IsRebind =
                    PathID == Connection->Paths[i].PathID &&
                    QuicAddrGetFamily(&Packet->Route->RemoteAddress) == QuicAddrGetFamily(&Connection->Paths[i].Route.RemoteAddress)
                    && QuicAddrCompareIp(&Packet->Route->RemoteAddress, &Connection->Paths[i].Route.RemoteAddress)
                    && QuicAddrCompare(&Packet->Route->LocalAddress, &Connection->Paths[i].Route.LocalAddress);
```

A rebind also no longer reinitializes the path ID's congestion control. It is the same path continuing, so it carries on with the state it had built up rather than starting over.

### CIDs were dropped once a packet ran out of frames

`QuicPathIDSetWriteNewConnectionIDFrame` and its RETIRE counterpart stopped visiting path IDs as soon as one reported `MaxFrameLimitHit`:

```c
    for (uint8_t i = 0; i < PathIDCount; i++) {
        if (!MaxFrameLimitHit1) {
            HaveRoom = QuicPathIDWriteNewConnectionIDFrame(...);
        }
        QuicPathIDRelease(PathIDs[i], QUIC_PATHID_REF_LOOKUP);
    }
```

Any CIDs the remaining path IDs still had to send went unreported, so `HasMoreCidsToSend` stayed clear. The caller reads that as nothing left to do:

```c
            if (!HasMoreCidsToSend) {
                Send->SendFlags &= ~QUIC_CONN_SEND_FLAG_NEW_CONNECTION_ID;
            }
```

The send flag was cleared and those CIDs were never sent in a later datagram.

Every path ID is now visited, and the lack of room is passed in as `NoRoom` so a full packet is reported on rather than written into. `HaveRoom` stays false for the caller once any path ID has run out.

### PATH_RESPONSE as connection control data

`QUIC_CONN_SEND_FLAG_PATH_RESPONSE` no longer counts as a reason to build a packet on the active path. Like a path challenge it is sent per path, and re-raised for a path that could not take one yet; treating that as connection control data produces a packet with nothing in it, since the frame belongs to a different path.

The same reasoning applies to `QUIC_CONN_SEND_FLAG_PATH_KEEP_ALIVE`, added in #74 after this fix was written, so it is excluded too.

## Testing

`*Multipath*:*Path*:*Migration*:*QMux*:*UnconnectedSocket*` (107 tests) and `*Basic*:*Datagram*:*Receive*:*Recv*` (622 tests) pass. No compiler warnings.

**No new tests.** None of the three is reachable from the existing test setups: the second needs a packet bearing an in-use path ID from an unrelated address, and the third needs enough path IDs with pending CIDs to exhaust a packet's frame budget. Worth covering, but each needs its own scaffolding rather than a line added to an existing test.

## Documentation

No documentation impact.
