### PR TITLE
Build for iOS and Android from cargo

### DIFF
--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -15,6 +15,10 @@ fn main() {
     overwrite_bindgen();
 }
 
+/// Minimum iOS version, kept in sync with `scripts/build.ps1 -Platform ios`.
+#[cfg(feature = "src")]
+const IOS_DEPLOYMENT_TARGET: &str = "13.0";
+
 #[cfg(feature = "src")]
 fn cmake_build() {
     use cmake::Config;
@@ -26,6 +30,7 @@ fn cmake_build() {
     }
 
     let target = env::var("TARGET").unwrap().replace("\\", "/");
+    let apple_ios = target.contains("-apple-ios");
     let out_dir = env::var("OUT_DIR").unwrap();
     // The output directory for the native MsQuic library.
     let quic_output_dir = if cfg!(windows) {
@@ -83,8 +88,37 @@ fn cmake_build() {
         config.define("QUIC_TLS_LIB", "quictls");
     }
 
-    if cfg!(feature = "static") {
+    if cfg!(feature = "static") || apple_ios {
         config.define("QUIC_BUILD_SHARED", "off");
+    }
+
+    // iOS needs the ios-cmake toolchain to select the SDK/architecture, and can
+    // only ever be built static (see the link attribute in src/rs/lib.rs). This
+    // mirrors `scripts/build.ps1 -Platform ios`.
+    if apple_ios {
+        // PLATFORM values are defined by cmake/toolchains/ios.cmake.
+        let platform = match target.as_str() {
+            "aarch64-apple-ios" => "OS64",
+            "aarch64-apple-ios-sim" => "SIMULATORARM64",
+            "x86_64-apple-ios" => "SIMULATOR64",
+            _ => panic!("Unsupported iOS target: {target}"),
+        };
+        let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let toolchain_file = Path::new(&manifest_dir)
+            .join("cmake")
+            .join("toolchains")
+            .join("ios.cmake");
+        config
+            .define("CMAKE_TOOLCHAIN_FILE", toolchain_file.to_str().unwrap())
+            .define("PLATFORM", platform)
+            .define("DEPLOYMENT_TARGET", IOS_DEPLOYMENT_TARGET)
+            .define("CMAKE_OSX_DEPLOYMENT_TARGET", IOS_DEPLOYMENT_TARGET)
+            .define("ENABLE_ARC", "0")
+            // Let the toolchain file own the compiler flags. Otherwise cmake-rs
+            // layers the `cc` crate's own -arch/-isysroot on top of the ones
+            // ios.cmake derived from PLATFORM.
+            .define("CMAKE_C_FLAGS", "")
+            .define("CMAKE_CXX_FLAGS", "");
     }
 
     // macos-latest's cargo automatically specify --target=${ARCH}-apple-macosx14.5
@@ -117,8 +151,14 @@ fn cmake_build() {
     if !found_lib_dir {
         panic!("no lib or lib64 directory found under {}", dst.display());
     }
-    if cfg!(feature = "static") {
-        if cfg!(target_os = "linux") {
+    if cfg!(feature = "static") || apple_ios {
+        // Keyed off the target rather than the host: cross-compiling to iOS
+        // happens from a macOS host, so `cfg!` would not tell them apart.
+        if target.contains("-apple-") {
+            // These back the darwin platform layer on macOS and iOS alike.
+            println!("cargo:rustc-link-lib=framework=CoreFoundation");
+            println!("cargo:rustc-link-lib=framework=Security");
+        } else if cfg!(target_os = "linux") {
             let numa_lib_path = match target.as_str() {
                 "x86_64-unknown-linux-gnu" => "/usr/lib/x86_64-linux-gnu",
                 "aarch64-unknown-linux-gnu" => "/usr/lib/aarch64-linux-gnu",
@@ -126,9 +166,6 @@ fn cmake_build() {
             };
             println!("cargo:rustc-link-search=native={numa_lib_path}");
             println!("cargo:rustc-link-lib=static:+whole-archive=numa");
-        } else if cfg!(target_os = "macos") {
-            println!("cargo:rustc-link-lib=framework=CoreFoundation");
-            println!("cargo:rustc-link-lib=framework=Security");
         } else if cfg!(windows) {
             // Windows system libraries that the static msquic.lib depends on.
             // These are excluded from the monolithic archive (via the inc/base_link

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -15,7 +15,7 @@ fn main() {
     overwrite_bindgen();
 }
 
-/// Minimum iOS version, kept in sync with `scripts/build.ps1 -Platform ios`.
+/// Default minimum iOS version, kept in sync with `scripts/build.ps1 -Platform ios`.
 #[cfg(feature = "src")]
 const IOS_DEPLOYMENT_TARGET: &str = "13.0";
 
@@ -108,11 +108,17 @@ fn cmake_build() {
             .join("cmake")
             .join("toolchains")
             .join("ios.cmake");
+        // Follow the consumer's IPHONEOS_DEPLOYMENT_TARGET when it sets one:
+        // rustc links against that version, and a link below the version these
+        // objects were compiled for leaves libSystem-versioned symbols such as
+        // `___chkstk_darwin` (iOS 12+) undefined.
+        let deployment_target = env::var("IPHONEOS_DEPLOYMENT_TARGET")
+            .unwrap_or_else(|_| IOS_DEPLOYMENT_TARGET.to_string());
         config
             .define("CMAKE_TOOLCHAIN_FILE", toolchain_file.to_str().unwrap())
             .define("PLATFORM", platform)
-            .define("DEPLOYMENT_TARGET", IOS_DEPLOYMENT_TARGET)
-            .define("CMAKE_OSX_DEPLOYMENT_TARGET", IOS_DEPLOYMENT_TARGET)
+            .define("DEPLOYMENT_TARGET", &deployment_target)
+            .define("CMAKE_OSX_DEPLOYMENT_TARGET", &deployment_target)
             .define("ENABLE_ARC", "0")
             // Let the toolchain file own the compiler flags. Otherwise cmake-rs
             // layers the `cc` crate's own -arch/-isysroot on top of the ones

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -169,13 +169,48 @@ fn cmake_build() {
             toolchain_file.exists(),
             "no android.toolchain.cmake under {ndk}; is that an NDK?",
         );
+        // quictls is configured by its own Perl script rather than by CMake,
+        // and `Configure android-arm64` looks the compiler up on PATH:
+        //
+        //     no NDK aarch64-linux-android-gcc on $PATH
+        //
+        // It also reads ANDROID_NDK_ROOT itself. build.ps1 sets both before
+        // invoking CMake; these are the same two, scoped to the child rather
+        // than to this process.
+        let host_tag = if cfg!(target_os = "macos") {
+            "darwin-x86_64"
+        } else if cfg!(windows) {
+            "windows-x86_64"
+        } else {
+            "linux-x86_64"
+        };
+        let ndk_bin = Path::new(&ndk)
+            .join("toolchains")
+            .join("llvm")
+            .join("prebuilt")
+            .join(host_tag)
+            .join("bin");
+        let path = match env::var_os("PATH") {
+            Some(existing) => {
+                let mut dirs = vec![ndk_bin];
+                dirs.extend(env::split_paths(&existing));
+                env::join_paths(dirs).expect("PATH with the NDK toolchain prepended")
+            }
+            None => ndk_bin.into_os_string(),
+        };
         config
             .define("CMAKE_TOOLCHAIN_FILE", toolchain_file.to_str().unwrap())
             .define("ANDROID_NDK", &ndk)
             .define("ANDROID_ABI", abi)
             // The floor quictls's own sub-build hardcodes, and what bionic
             // needs for the glob() in selfsign_openssl.c.
-            .define("ANDROID_PLATFORM", "android-29");
+            .define("ANDROID_PLATFORM", "android-29")
+            .env("PATH", path)
+            // Set from the NDK actually being used, so a machine with a second
+            // one already pointed at by this variable does not end up
+            // compiling with one and configuring with the other.
+            .env("ANDROID_NDK_ROOT", &ndk)
+            .env("ANDROID_NDK_HOME", &ndk);
     }
 
     // macos-latest's cargo automatically specify --target=${ARCH}-apple-macosx14.5

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -31,6 +31,7 @@ fn cmake_build() {
 
     let target = env::var("TARGET").unwrap().replace("\\", "/");
     let apple_ios = target.contains("-apple-ios");
+    let android = target.contains("-linux-android");
     let out_dir = env::var("OUT_DIR").unwrap();
     // The output directory for the native MsQuic library.
     let quic_output_dir = if cfg!(windows) {
@@ -125,6 +126,56 @@ fn cmake_build() {
             // ios.cmake derived from PLATFORM.
             .define("CMAKE_C_FLAGS", "")
             .define("CMAKE_CXX_FLAGS", "");
+    }
+
+    // Android needs the NDK's own CMake toolchain, and above all `ANDROID_ABI`.
+    //
+    // Without it, cmake-rs sets `CMAKE_SYSTEM_NAME=Android` from the target
+    // triple and nothing else, so CMake takes its *built-in* Android support
+    // (`Modules/Platform/Android-Clang.cmake`) and `ANDROID_ABI` -- a variable
+    // the NDK toolchain file owns -- is never set. `submodules/CMakeLists.txt`
+    // reads it to choose quictls's `Configure` target and stops with "Unknown
+    // android abi type".
+    //
+    // The four defines below are what `scripts/build.ps1 -Platform android`
+    // passes; this is the same recipe reached from cargo instead of PowerShell.
+    // They cannot be supplied from outside: cmake-rs forwards only
+    // CMAKE_TOOLCHAIN_FILE, CMAKE_GENERATOR, CMAKE_PREFIX_PATH, CMAKE, EMCMAKE
+    // and EMMAKE from the environment, so `ANDROID_ABI` has to be passed here.
+    if android {
+        let abi = match target.as_str() {
+            "aarch64-linux-android" => "arm64-v8a",
+            "armv7-linux-androideabi" => "armeabi-v7a",
+            "i686-linux-android" => "x86",
+            "x86_64-linux-android" => "x86_64",
+            _ => panic!("Unsupported Android target: {target}"),
+        };
+        // `ANDROID_NDK_HOME` is what the NDK's own tooling and cargo-ndk set;
+        // `ANDROID_NDK_LATEST_HOME` is what GitHub's runners provide and what
+        // build.ps1 reads. Accept either rather than making the caller know
+        // which convention this build script grew up with.
+        let ndk = env::var("ANDROID_NDK_HOME")
+            .or_else(|_| env::var("ANDROID_NDK_ROOT"))
+            .or_else(|_| env::var("ANDROID_NDK_LATEST_HOME"))
+            .expect(
+                "building for Android needs the NDK: set ANDROID_NDK_HOME \
+                 (or ANDROID_NDK_ROOT / ANDROID_NDK_LATEST_HOME)",
+            );
+        let toolchain_file = Path::new(&ndk)
+            .join("build")
+            .join("cmake")
+            .join("android.toolchain.cmake");
+        assert!(
+            toolchain_file.exists(),
+            "no android.toolchain.cmake under {ndk}; is that an NDK?",
+        );
+        config
+            .define("CMAKE_TOOLCHAIN_FILE", toolchain_file.to_str().unwrap())
+            .define("ANDROID_NDK", &ndk)
+            .define("ANDROID_ABI", abi)
+            // The floor quictls's own sub-build hardcodes, and what bionic
+            // needs for the glob() in selfsign_openssl.c.
+            .define("ANDROID_PLATFORM", "android-29");
     }
 
     // macos-latest's cargo automatically specify --target=${ARCH}-apple-macosx14.5

--- a/src/rs/config.rs
+++ b/src/rs/config.rs
@@ -411,9 +411,9 @@ impl Default for AllowedCipherSuiteFlags {
     }
 }
 
-// Disable macos because the ffi bindings is using linux
-// for macos and it has error code mismatch.
-#[cfg(not(target_os = "macos"))]
+// Disable macos/ios because the ffi bindings is using linux
+// for them and it has error code mismatch.
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/src/rs/config.rs
+++ b/src/rs/config.rs
@@ -224,10 +224,18 @@ impl CertificateHashStore {
         // prepare slice with nul terminator
         let c_str = CString::new(store_name).unwrap();
         let c_slice = c_str.as_bytes_with_nul();
-        let c_slice2 =
-            unsafe { std::slice::from_raw_parts(c_slice.as_ptr() as *const i8, c_slice.len()) };
+        // `c_char` rather than `i8`: it is unsigned on aarch64 Linux and
+        // Android, and the generated binding declares `StoreName` as
+        // `[c_char; 128]`, so hardcoding the signedness only compiles where the
+        // bindings happened to be generated.
+        let c_slice2 = unsafe {
+            std::slice::from_raw_parts(
+                c_slice.as_ptr() as *const ::std::os::raw::c_char,
+                c_slice.len(),
+            )
+        };
         // copy with nul terminator
-        let mut name_buff = [0_i8; 128];
+        let mut name_buff = [0 as ::std::os::raw::c_char; 128];
         let chunk = &mut name_buff[..c_slice2.len()];
         chunk.copy_from_slice(c_slice2);
         Self(crate::ffi::QUIC_CERTIFICATE_HASH_STORE {

--- a/src/rs/ffi/mod.rs
+++ b/src/rs/ffi/mod.rs
@@ -49,10 +49,12 @@ pub struct OVERLAPPED_ENTRY {
 #[cfg(target_os = "linux")]
 pub type epoll_event = libc::epoll_event;
 
-#[cfg(target_os = "macos")]
+// iOS shares the darwin platform layer (kqueue, not epoll) with macOS, so it
+// takes the same placeholder.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub type epoll_event = u32; // HACK: TODO - Fix once we have macOS support
 
-// TODO: macos currently is using the linux bindings.
+// TODO: macos/ios currently is using the linux bindings.
 #[cfg(not(target_os = "windows"))]
 pub type sa_family_t = u16;
 #[cfg(not(target_os = "windows"))]

--- a/src/rs/ffi/mod.rs
+++ b/src/rs/ffi/mod.rs
@@ -46,7 +46,9 @@ pub struct OVERLAPPED_ENTRY {
     pub dwNumberOfBytesTransferred: ::std::os::raw::c_ulong,
 }
 
-#[cfg(target_os = "linux")]
+// Android is bionic on the same kernel, so it has epoll and takes the real
+// type — unlike the darwin targets below, which are on kqueue.
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub type epoll_event = libc::epoll_event;
 
 // iOS shares the darwin platform layer (kqueue, not epoll) with macOS, so it

--- a/src/rs/lib.rs
+++ b/src/rs/lib.rs
@@ -381,9 +381,16 @@ pub const PARAM_STREAM_0RTT_LENGTH: u32 = 0x08000001;
 pub const PARAM_STREAM_IDEAL_SEND_BUFFER_SIZE: u32 = 0x08000002;
 pub const PARAM_STREAM_PRIORITY: u32 = 0x08000003;
 
-#[cfg_attr(not(feature = "static"), link(name = "msquic", kind = "dylib"))]
+// iOS app bundles cannot load a side-loaded dylib, so msquic is always linked
+// statically there regardless of the `static` feature. scripts/build.rs forces
+// QUIC_BUILD_SHARED=off to match, the same way scripts/build.ps1 forces
+// -Static for -Platform ios.
 #[cfg_attr(
-    feature = "static",
+    all(not(feature = "static"), not(target_os = "ios")),
+    link(name = "msquic", kind = "dylib")
+)]
+#[cfg_attr(
+    any(feature = "static", target_os = "ios"),
     link(name = "msquic", kind = "static", modifiers = "-bundle")
 )]
 unsafe extern "C" {

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -259,9 +259,12 @@ else()
         # cmake/toolchains/ios.cmake from PLATFORM.
         if (SDK_NAME MATCHES "^iphonesimulator")
             # iossimulator-xcrun leaves the architecture at the compiler default
-            # (the host's), so pin it to the one CMake is targeting.
+            # (the host's), so pin it to the one CMake is targeting. Configure
+            # reads a bare word as the target name, so the flag and its value
+            # have to arrive as one argument — %20 is Configure's own escape for
+            # the space (see the arg loop in quictls/Configure).
             set(OPENSSL_CONFIG_CMD ${CMAKE_CURRENT_SOURCE_DIR}/${QUIC_OPENSSL}/Configure iossimulator-xcrun)
-            list(APPEND OPENSSL_CONFIG_FLAGS -arch ${CMAKE_OSX_ARCHITECTURES})
+            list(APPEND OPENSSL_CONFIG_FLAGS "-arch%20${CMAKE_OSX_ARCHITECTURES}")
         elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
             set(OPENSSL_CONFIG_CMD ${CMAKE_CURRENT_SOURCE_DIR}/${QUIC_OPENSSL}/Configure ios64-xcrun)
         else()

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -253,6 +253,28 @@ else()
                             CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER})
             endif()
         endif()
+    elseif(CX_PLATFORM STREQUAL "darwin" AND CMAKE_SYSTEM_NAME STREQUAL "iOS")
+        # The darwin64-* targets bake in macOS-only configuration, so iOS picks
+        # its own OpenSSL target. SDK_NAME/CMAKE_OSX_ARCHITECTURES are set by
+        # cmake/toolchains/ios.cmake from PLATFORM.
+        if (SDK_NAME MATCHES "^iphonesimulator")
+            # iossimulator-xcrun leaves the architecture at the compiler default
+            # (the host's), so pin it to the one CMake is targeting.
+            set(OPENSSL_CONFIG_CMD ${CMAKE_CURRENT_SOURCE_DIR}/${QUIC_OPENSSL}/Configure iossimulator-xcrun)
+            list(APPEND OPENSSL_CONFIG_FLAGS -arch ${CMAKE_OSX_ARCHITECTURES})
+        elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
+            set(OPENSSL_CONFIG_CMD ${CMAKE_CURRENT_SOURCE_DIR}/${QUIC_OPENSSL}/Configure ios64-xcrun)
+        else()
+            message(FATAL_ERROR "Unsupported iOS architecture: ${CMAKE_OSX_ARCHITECTURES}")
+        endif()
+
+        list(APPEND OPENSSL_CONFIG_FLAGS
+            -isysroot ${CMAKE_OSX_SYSROOT}
+            "-m${SDK_NAME}-version-min=${DEPLOYMENT_TARGET}")
+
+        if (ENABLE_BITCODE)
+            list(APPEND OPENSSL_CONFIG_FLAGS -fembed-bitcode)
+        endif()
     elseif(CX_PLATFORM STREQUAL "darwin")
         if (CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
             set(OPENSSL_CONFIG_CMD ARCHFLAGS="-arch arm64" ${CMAKE_CURRENT_SOURCE_DIR}/${QUIC_OPENSSL}/Configure darwin64-arm64-cc)


### PR DESCRIPTION
Cross-compiling the Rust crate for **iOS** and **Android** onto `seera-main`.
Four commits: the two iOS ones already on `masa-koz/qmux-01`, unchanged in
substance, and two new Android ones. Raised here rather than on `qmux-01` so it
can be merged forward.

Everything is inside `if apple_ios` / `if android`, so no other target's
configure line changes.

## iOS (`b7c3e916`, `2fb5478a`)

The pair from `qmux-01`. `cargo build --target aarch64-apple-ios{,-sim}` failed
before CMake was reached — `ffi/mod.rs` defined `epoll_event` for linux and
macos only, while `linux_bindings.rs` is included for every non-Windows target
— plus the ios-cmake toolchain, `QUIC_BUILD_SHARED=off` (an app bundle cannot
load a side-loaded dylib), quictls's `-arch%20arm64` escaping, and the
`IPHONEOS_DEPLOYMENT_TARGET` that keeps `___chkstk_darwin` defined.

One conflict, resolved in favour of `seera-main`: it has since grown a
`lib`/`lib64` search-path loop where the iOS commit had a single `path_extra`.
The loop is kept; what the iOS commit adds on top of it — `|| apple_ios`, and
linking CoreFoundation and Security for `-apple-` targets — is merged into it.

## Android: `ANDROID_ABI` never reaches CMake (`88602fe5`)

```
CMake Error at submodules/CMakeLists.txt:219 (message):
  Unknown android abi type
```

cmake-rs sets `CMAKE_SYSTEM_NAME=Android` from the target triple and nothing
else, so CMake takes its **built-in** Android support
(`Modules/Platform/Android-Clang.cmake`) rather than the NDK's toolchain file —
and `ANDROID_ABI`, which that toolchain file owns, is never set.
`submodules/CMakeLists.txt` reads it to pick quictls's `Configure` target.

It cannot be supplied from outside either: cmake-rs forwards exactly
`CMAKE_TOOLCHAIN_FILE`, `CMAKE_GENERATOR`, `CMAKE_PREFIX_PATH`, `CMAKE`,
`EMCMAKE` and `EMMAKE` from the environment, so the define has to come from the
build script. The four values are the ones `build.ps1 -Platform android` passes:
the toolchain file, `ANDROID_NDK`, `ANDROID_ABI`, and
`ANDROID_PLATFORM=android-29`. Same recipe, reached from cargo instead of
PowerShell, so the two stay comparable.

## Android: quictls is not configured by CMake (`99606525`)

With the defines in place the build gets as far as

```
no NDK aarch64-linux-android-gcc on $PATH
```

quictls is configured by its own Perl script, so the CMake toolchain file does
not reach it: `Configure android-arm64` looks the compiler up on `PATH` and
reads `ANDROID_NDK_ROOT` itself. `build.ps1` sets both before invoking CMake;
this sets the same two, scoped to the child process rather than to this one.

`ANDROID_NDK_ROOT` is set from the NDK actually in use, because a machine can
easily have two — GitHub's runners ship one and let you install another — and
configuring against one while compiling with the other fails much later and
much less clearly. The NDK itself is looked up as `ANDROID_NDK_HOME`, then
`ANDROID_NDK_ROOT`, then `ANDROID_NDK_LATEST_HOME`, because cargo-ndk, the
NDK's own tooling and GitHub's runners do not agree on which to set. A missing
NDK, or a path with no `android.toolchain.cmake` under it, says that rather
than failing as a CMake error forty lines deep.

## Checked

The Android half was driven from the consumer side — an Android app whose
Gradle build cross-compiles this crate through `cargo ndk` — on
`masa-koz/qmux-01`, where the same two commits are the ones under test in
seera-networks/ISEKAI-link#133. Before: the two failures above, in that order.
After: quictls configures and builds, and msquic compiles.

`x86_64`, `armv7` and `i686` are mapped alongside `arm64` for completeness, but
only `aarch64-linux-android` has been built. The iOS commits are unchanged from
`qmux-01` apart from the merge described above, and have not been rebuilt on
this base — there is no macOS runner in reach of this branch.
