### PR TITLE
Add QUIC_PARAM_CONN_PATH_STATISTICS for per-path network statistics

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -224,6 +224,32 @@ These parameters are accessed by calling [GetParam](./api/GetParam.md) or [SetPa
 | `QUIC_PARAM_CONN_REMOVE_CANDIDATE_ADDRESS` <br> 34| QUIC_CANDIDATE_ADDRESS        | Set-only  | Remove a candidate address. Client only. |
 
 | `QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET` <br> 37 | uint8_t (BOOLEAN) | Both | Set on client only. Must be set before start, and requires `QUIC_PARAM_CONN_SHARE_UDP_BINDING`. See [QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET](#quic_param_conn_unconnected_udp_socket). |
+| `QUIC_PARAM_CONN_PATH_STATISTICS` <br> 38 | QUIC_PATH_STATISTICS[] | Get-only | Network statistics for every path at once, one array entry per path. See [QUIC_PARAM_CONN_PATH_STATISTICS](#quic_param_conn_path_statistics). |
+
+### QUIC_PARAM_CONN_PATH_STATISTICS
+
+Returns an array of `QUIC_PATH_STATISTICS`, one entry per path the connection currently holds. It is the per-path counterpart of `QUIC_PARAM_CONN_NETWORK_STATISTICS`, which only ever reports the first path.
+
+The number of paths is not known in advance and changes over the life of the connection, so call it the usual two-step way: pass a `BufferLength` of `0` to be told the size needed, then call again with a buffer at least that large. A buffer too small for the current number of paths returns `QUIC_STATUS_BUFFER_TOO_SMALL` with `BufferLength` set to the required size. On success `BufferLength` is set to the number of bytes actually written, so the entry count is `BufferLength / sizeof(QUIC_PATH_STATISTICS)`.
+
+```c
+typedef struct QUIC_PATH_STATISTICS {
+    uint32_t PathId;
+    uint64_t Rtt;
+    uint64_t MinRtt;
+    uint64_t MaxRtt;
+    uint16_t Mtu;
+    QUIC_NETWORK_STATISTICS NetworkStatistics;
+} QUIC_PATH_STATISTICS;
+```
+
+`PathId` identifies which path an entry describes. It is needed because array position is not stable: paths are removed and the remaining ones move up, so the entry at a given index is not necessarily the same path it was on the previous call. It matches the `PathId` used by `QUIC_PARAM_CONN_PATH_STATUS`.
+
+`MinRtt` and `MaxRtt` are zero until the path has produced an RTT sample. `Rtt` is the smoothed RTT, which starts from the configured `InitialRttMs` and so is non-zero from the outset.
+
+Paths that exist but have no path ID assigned yet — a path added before the handshake is confirmed — are not reported, since there is nothing to identify them by and no congestion control to read from.
+
+Works whether or not multipath was negotiated; a connection with a single path returns one entry.
 
 ### QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -222,7 +222,6 @@ These parameters are accessed by calling [GetParam](./api/GetParam.md) or [SetPa
 | `QUIC_PARAM_CONN_REMOVE_PATH` <br> 32             | QUIC_PATH_PARAM               | Set-only  | Remove a path. Client only. |
 | `QUIC_PARAM_CONN_ADD_CANDIDATE_ADDRESS` <br> 33   | QUIC_CANDIDATE_ADDRESS        | Set-only  | Add a candidate address. Client only. |
 | `QUIC_PARAM_CONN_REMOVE_CANDIDATE_ADDRESS` <br> 34| QUIC_CANDIDATE_ADDRESS        | Set-only  | Remove a candidate address. Client only. |
-
 | `QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET` <br> 37 | uint8_t (BOOLEAN) | Both | Set on client only. Must be set before start, and requires `QUIC_PARAM_CONN_SHARE_UDP_BINDING`. See [QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET](#quic_param_conn_unconnected_udp_socket). |
 | `QUIC_PARAM_CONN_PATH_STATISTICS` <br> 38 | QUIC_PATH_STATISTICS[] | Get-only | Network statistics for every path at once, one array entry per path. See [QUIC_PARAM_CONN_PATH_STATISTICS](#quic_param_conn_path_statistics). |
 
@@ -244,6 +243,8 @@ typedef struct QUIC_PATH_STATISTICS {
 ```
 
 `PathId` identifies which path an entry describes. It is needed because array position is not stable: paths are removed and the remaining ones move up, so the entry at a given index is not necessarily the same path it was on the previous call. It matches the `PathId` used by `QUIC_PARAM_CONN_PATH_STATUS`.
+
+It is not guaranteed unique. While a path is being rebound — the peer reappearing on a new port through a NAT, for instance — the new path and the one it replaces briefly share a path ID, and both are reported. The two entries carry that path ID's congestion control, so their `NetworkStatistics` agree; what tells them apart is the per-path `Rtt`, `MinRtt`, `MaxRtt` and `Mtu`.
 
 `MinRtt` and `MaxRtt` are zero until the path has produced an RTT sample. `Rtt` is the smoothed RTT, which starts from the configured `InitialRttMs` and so is non-zero from the outset.
 

--- a/src/core/bbr.c
+++ b/src/core/bbr.c
@@ -306,15 +306,11 @@ void
 BbrCongestionControlGetNetworkStatistics(
     _In_ const QUIC_CONNECTION* const Connection,
     _In_ const QUIC_CONGESTION_CONTROL* const Cc,
+    _In_ const QUIC_PATH* const Path,
     _Out_ QUIC_NETWORK_STATISTICS* NetworkStatistics
     )
 {
     const QUIC_CONGESTION_CONTROL_BBR* Bbr = &Cc->Bbr;
-    //
-    // Congestion control is per path ID, so the RTT to report is the one of the
-    // path this instance belongs to, not whichever path happens to be first.
-    //
-    const QUIC_PATH* Path = QuicCongestionControlGetPathID(Cc)->Path;
 
     NetworkStatistics->BytesInFlight = Bbr->BytesInFlight;
     NetworkStatistics->PostedBytes = Connection->SendBuffer.PostedBytes;
@@ -334,7 +330,11 @@ BbrCongestionControlIndicateConnectionEvent(
     QUIC_CONNECTION_EVENT Event;
     Event.Type = QUIC_CONNECTION_EVENT_NETWORK_STATISTICS;
 
-    BbrCongestionControlGetNetworkStatistics(Connection, Cc, &Event.NETWORK_STATISTICS);
+    //
+    // The connection-level event has always reported the active path.
+    //
+    BbrCongestionControlGetNetworkStatistics(
+        Connection, Cc, &Connection->Paths[0], &Event.NETWORK_STATISTICS);
 
     QuicTraceLogConnVerbose(
         IndicateDataAcked,

--- a/src/core/bbr.c
+++ b/src/core/bbr.c
@@ -310,7 +310,11 @@ BbrCongestionControlGetNetworkStatistics(
     )
 {
     const QUIC_CONGESTION_CONTROL_BBR* Bbr = &Cc->Bbr;
-    const QUIC_PATH* Path = &Connection->Paths[0];
+    //
+    // Congestion control is per path ID, so the RTT to report is the one of the
+    // path this instance belongs to, not whichever path happens to be first.
+    //
+    const QUIC_PATH* Path = QuicCongestionControlGetPathID(Cc)->Path;
 
     NetworkStatistics->BytesInFlight = Bbr->BytesInFlight;
     NetworkStatistics->PostedBytes = Connection->SendBuffer.PostedBytes;

--- a/src/core/congestion_control.h
+++ b/src/core/congestion_control.h
@@ -155,9 +155,16 @@ typedef struct QUIC_CONGESTION_CONTROL {
         _In_ struct QUIC_CONGESTION_CONTROL* Cc
         );
 
+    //
+    // Path is passed in rather than derived from Cc: without multipath,
+    // QuicPathSetActive swaps the contents of two QUIC_PATH slots and leaves
+    // the owning path ID's back pointer behind, so the caller is the only one
+    // that reliably knows which path it is asking about.
+    //
     void (*QuicCongestionControlGetNetworkStatistics)(
         _In_ const QUIC_CONNECTION* const Connection,
         _In_ const struct QUIC_CONGESTION_CONTROL* const Cc,
+        _In_ const struct QUIC_PATH* const Path,
         _Out_ struct QUIC_NETWORK_STATISTICS* NetworkStatistics
         );
 

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -9315,7 +9315,8 @@ QuicConnGetNetworkStatistics(
     CxPlatZeroMemory(Stats, sizeof(QUIC_NETWORK_STATISTICS));
 
     Connection->Paths[0].PathID->CongestionControl.QuicCongestionControlGetNetworkStatistics(
-        Connection, &Connection->Paths[0].PathID->CongestionControl, Stats);
+        Connection, &Connection->Paths[0].PathID->CongestionControl,
+        &Connection->Paths[0], Stats);
 
     return QUIC_STATUS_SUCCESS;
 }
@@ -9377,7 +9378,8 @@ QuicConnGetPathStatistics(
         PathStats->Mtu = Path->Mtu;
 
         Path->PathID->CongestionControl.QuicCongestionControlGetNetworkStatistics(
-            Connection, &Path->PathID->CongestionControl, &PathStats->NetworkStatistics);
+            Connection, &Path->PathID->CongestionControl, Path,
+            &PathStats->NetworkStatistics);
     }
 
     CXPLAT_DBG_ASSERT(Index == PathCount);

--- a/src/core/connection.c
+++ b/src/core/connection.c
@@ -9321,6 +9321,73 @@ QuicConnGetNetworkStatistics(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
+static
+QUIC_STATUS
+QuicConnGetPathStatistics(
+    _In_ const QUIC_CONNECTION* Connection,
+    _Inout_ uint32_t* StatsLength,
+    _Out_writes_bytes_opt_(*StatsLength)
+        QUIC_PATH_STATISTICS* Stats
+    )
+{
+    //
+    // Only paths that are in use and have a path ID can be reported on: the
+    // path ID is what identifies the entry to the caller, and it owns the
+    // congestion control the network statistics come from. A path added before
+    // the handshake is confirmed has neither yet.
+    //
+    uint8_t PathCount = 0;
+    for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
+        if (Connection->Paths[i].InUse && Connection->Paths[i].PathID != NULL) {
+            PathCount++;
+        }
+    }
+
+    const uint32_t RequiredLength = PathCount * sizeof(QUIC_PATH_STATISTICS);
+
+    if (*StatsLength < RequiredLength) {
+        *StatsLength = RequiredLength;
+        return QUIC_STATUS_BUFFER_TOO_SMALL;
+    }
+
+    if (Stats == NULL) {
+        return QUIC_STATUS_INVALID_PARAMETER;
+    }
+
+    CxPlatZeroMemory(Stats, RequiredLength);
+
+    uint8_t Index = 0;
+    for (uint8_t i = 0; i < Connection->PathsCount; ++i) {
+        const QUIC_PATH* Path = &Connection->Paths[i];
+        if (!Path->InUse || Path->PathID == NULL) {
+            continue;
+        }
+
+        QUIC_PATH_STATISTICS* PathStats = &Stats[Index++];
+        PathStats->PathId = Path->PathID->ID;
+        PathStats->Rtt = Path->SmoothedRtt;
+        //
+        // Until the path has produced an RTT sample, MinRtt still holds the
+        // sentinel it was initialized to and MaxRtt is untouched. Reporting
+        // those as microsecond counts would read as a minimum of over an hour,
+        // so a path with nothing measured reports zero for both.
+        //
+        PathStats->MinRtt = Path->GotFirstRttSample ? Path->MinRtt : 0;
+        PathStats->MaxRtt = Path->GotFirstRttSample ? Path->MaxRtt : 0;
+        PathStats->Mtu = Path->Mtu;
+
+        Path->PathID->CongestionControl.QuicCongestionControlGetNetworkStatistics(
+            Connection, &Path->PathID->CongestionControl, &PathStats->NetworkStatistics);
+    }
+
+    CXPLAT_DBG_ASSERT(Index == PathCount);
+
+    *StatsLength = RequiredLength;
+
+    return QUIC_STATUS_SUCCESS;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
 QUIC_STATUS
 QuicConnParamGet(
     _In_ QUIC_CONNECTION* Connection,
@@ -9762,6 +9829,11 @@ QuicConnParamGet(
     case QUIC_PARAM_CONN_NETWORK_STATISTICS:
         Status =
             QuicConnGetNetworkStatistics(Connection, BufferLength, (QUIC_NETWORK_STATISTICS *)Buffer);
+        break;
+
+    case QUIC_PARAM_CONN_PATH_STATISTICS:
+        Status =
+            QuicConnGetPathStatistics(Connection, BufferLength, (QUIC_PATH_STATISTICS *)Buffer);
         break;
 
     case QUIC_PARAM_CONN_CLOSE_ASYNC:

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -429,15 +429,11 @@ void
 CubicCongestionControlGetNetworkStatistics(
     _In_ const QUIC_CONNECTION* const Connection,
     _In_ const QUIC_CONGESTION_CONTROL* const Cc,
+    _In_ const QUIC_PATH* const Path,
     _Out_ QUIC_NETWORK_STATISTICS* NetworkStatistics
     )
 {
     const QUIC_CONGESTION_CONTROL_CUBIC* Cubic = &Cc->Cubic;
-    //
-    // Congestion control is per path ID, so the RTT to report is the one of the
-    // path this instance belongs to, not whichever path happens to be first.
-    //
-    const QUIC_PATH* Path = QuicCongestionControlGetPathID(Cc)->Path;
 
     NetworkStatistics->BytesInFlight = Cubic->BytesInFlight;
     NetworkStatistics->PostedBytes = Connection->SendBuffer.PostedBytes;

--- a/src/core/cubic.c
+++ b/src/core/cubic.c
@@ -433,7 +433,11 @@ CubicCongestionControlGetNetworkStatistics(
     )
 {
     const QUIC_CONGESTION_CONTROL_CUBIC* Cubic = &Cc->Cubic;
-    const QUIC_PATH* Path = &Connection->Paths[0];
+    //
+    // Congestion control is per path ID, so the RTT to report is the one of the
+    // path this instance belongs to, not whichever path happens to be first.
+    //
+    const QUIC_PATH* Path = QuicCongestionControlGetPathID(Cc)->Path;
 
     NetworkStatistics->BytesInFlight = Cubic->BytesInFlight;
     NetworkStatistics->PostedBytes = Connection->SendBuffer.PostedBytes;

--- a/src/core/unittest/BbrTest.cpp
+++ b/src/core/unittest/BbrTest.cpp
@@ -1087,7 +1087,8 @@ TEST_F(BbrTest_DeepTest, GetNetworkStatistics)
     CC->QuicCongestionControlOnDataSent(CC, 5000);
 
     QUIC_NETWORK_STATISTICS Stats{};
-    CC->QuicCongestionControlGetNetworkStatistics(&Connection, CC, &Stats);
+    CC->QuicCongestionControlGetNetworkStatistics(
+        &Connection, CC, &Connection.Paths[0], &Stats);
 
     ASSERT_EQ(Stats.BytesInFlight, 5000u);
     ASSERT_EQ(Stats.CongestionWindow, CC->QuicCongestionControlGetCongestionWindow(CC));

--- a/src/core/unittest/CubicTest.cpp
+++ b/src/core/unittest/CubicTest.cpp
@@ -1271,7 +1271,8 @@ TEST_F(CubicTest, GetNetworkStatistics_RetrieveStats)
     CxPlatZeroMemory(&NetworkStats, sizeof(NetworkStats));
 
     // Call through function pointer - note it takes Connection as first param
-    CC->QuicCongestionControlGetNetworkStatistics(&Connection,CC,&NetworkStats);
+    CC->QuicCongestionControlGetNetworkStatistics(
+        &Connection, CC, &Connection.Paths[0], &NetworkStats);
 
     // Verify all 6 statistics fields were populated
     ASSERT_EQ(NetworkStats.CongestionWindow, Cubic->CongestionWindow);
@@ -1310,7 +1311,8 @@ TEST_F(CubicTest, GetNetworkStatistics_ZeroSmoothedRtt_BandwidthIsZero)
     CxPlatZeroMemory(&NetworkStats, sizeof(NetworkStats));
 
     // Must not crash with divide-by-zero when SmoothedRtt == 0.
-    CC->QuicCongestionControlGetNetworkStatistics(&Connection, CC, &NetworkStats);
+    CC->QuicCongestionControlGetNetworkStatistics(
+        &Connection, CC, &Connection.Paths[0], &NetworkStats);
 
     ASSERT_EQ(NetworkStats.Bandwidth, 0u);
     ASSERT_EQ(NetworkStats.SmoothedRTT, 0u);

--- a/src/inc/msquic.h
+++ b/src/inc/msquic.h
@@ -778,6 +778,19 @@ typedef struct QUIC_PATH_STATUS {
     uint32_t PathId;
     BOOLEAN Active;
 } QUIC_PATH_STATUS;
+
+//
+// Per-path counterpart of QUIC_NETWORK_STATISTICS. Retrieved for every path at
+// once via QUIC_PARAM_CONN_PATH_STATISTICS, which writes an array of these.
+//
+typedef struct QUIC_PATH_STATISTICS {
+    uint32_t PathId;                     // Identifies which path this entry describes
+    uint64_t Rtt;                        // Smoothed RTT for the path, in microseconds
+    uint64_t MinRtt;                     // Minimum RTT observed on the path, in microseconds. Zero until the path has an RTT sample.
+    uint64_t MaxRtt;                     // Maximum RTT observed on the path, in microseconds. Zero until the path has an RTT sample.
+    uint16_t Mtu;                        // Currently calculated path MTU
+    QUIC_NETWORK_STATISTICS NetworkStatistics;
+} QUIC_PATH_STATISTICS;
 #endif
 
 typedef struct QUIC_GLOBAL_SETTINGS {
@@ -1129,6 +1142,7 @@ typedef struct QUIC_SCHANNEL_CREDENTIAL_ATTRIBUTE_W {
 #define QUIC_PARAM_CONN_REMOVE_CANDIDATE_ADDRESS        0x05000023  // QUIC_CANDIDATE_ADDRESS
 #define QUIC_PARAM_CONN_PATH_STATUS                     0x05000024  // QUIC_PATH_STATUS
 #define QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET          0x05000025  // uint8_t (BOOLEAN)
+#define QUIC_PARAM_CONN_PATH_STATISTICS                 0x05000026  // QUIC_PATH_STATISTICS[]
 #endif
 
 //

--- a/src/rs/ffi/linux_bindings.rs
+++ b/src/rs/ffi/linux_bindings.rs
@@ -222,6 +222,7 @@ pub const QUIC_PARAM_CONN_ADD_CANDIDATE_ADDRESS: u32 = 83886114;
 pub const QUIC_PARAM_CONN_REMOVE_CANDIDATE_ADDRESS: u32 = 83886115;
 pub const QUIC_PARAM_CONN_PATH_STATUS: u32 = 83886116;
 pub const QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET: u32 = 83886117;
+pub const QUIC_PARAM_CONN_PATH_STATISTICS: u32 = 83886118;
 pub const QUIC_PARAM_TLS_HANDSHAKE_INFO: u32 = 100663296;
 pub const QUIC_PARAM_TLS_NEGOTIATED_ALPN: u32 = 100663297;
 pub const QUIC_PARAM_STREAM_ID: u32 = 134217728;
@@ -1829,6 +1830,33 @@ const _: () = {
         [::std::mem::offset_of!(QUIC_PATH_STATUS, PathId) - 0usize];
     ["Offset of field: QUIC_PATH_STATUS::Active"]
         [::std::mem::offset_of!(QUIC_PATH_STATUS, Active) - 4usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct QUIC_PATH_STATISTICS {
+    pub PathId: u32,
+    pub Rtt: u64,
+    pub MinRtt: u64,
+    pub MaxRtt: u64,
+    pub Mtu: u16,
+    pub NetworkStatistics: QUIC_NETWORK_STATISTICS,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of QUIC_PATH_STATISTICS"][::std::mem::size_of::<QUIC_PATH_STATISTICS>() - 88usize];
+    ["Alignment of QUIC_PATH_STATISTICS"][::std::mem::align_of::<QUIC_PATH_STATISTICS>() - 8usize];
+    ["Offset of field: QUIC_PATH_STATISTICS::PathId"]
+        [::std::mem::offset_of!(QUIC_PATH_STATISTICS, PathId) - 0usize];
+    ["Offset of field: QUIC_PATH_STATISTICS::Rtt"]
+        [::std::mem::offset_of!(QUIC_PATH_STATISTICS, Rtt) - 8usize];
+    ["Offset of field: QUIC_PATH_STATISTICS::MinRtt"]
+        [::std::mem::offset_of!(QUIC_PATH_STATISTICS, MinRtt) - 16usize];
+    ["Offset of field: QUIC_PATH_STATISTICS::MaxRtt"]
+        [::std::mem::offset_of!(QUIC_PATH_STATISTICS, MaxRtt) - 24usize];
+    ["Offset of field: QUIC_PATH_STATISTICS::Mtu"]
+        [::std::mem::offset_of!(QUIC_PATH_STATISTICS, Mtu) - 32usize];
+    ["Offset of field: QUIC_PATH_STATISTICS::NetworkStatistics"]
+        [::std::mem::offset_of!(QUIC_PATH_STATISTICS, NetworkStatistics) - 40usize];
 };
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/rs/ffi/win_bindings.rs
+++ b/src/rs/ffi/win_bindings.rs
@@ -216,6 +216,7 @@ pub const QUIC_PARAM_CONN_ADD_CANDIDATE_ADDRESS: u32 = 83886114;
 pub const QUIC_PARAM_CONN_REMOVE_CANDIDATE_ADDRESS: u32 = 83886115;
 pub const QUIC_PARAM_CONN_PATH_STATUS: u32 = 83886116;
 pub const QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET: u32 = 83886117;
+pub const QUIC_PARAM_CONN_PATH_STATISTICS: u32 = 83886118;
 pub const QUIC_PARAM_TLS_HANDSHAKE_INFO: u32 = 100663296;
 pub const QUIC_PARAM_TLS_NEGOTIATED_ALPN: u32 = 100663297;
 pub const QUIC_PARAM_TLS_SCHANNEL_CONTEXT_ATTRIBUTE_W: u32 = 117440512;
@@ -1822,6 +1823,33 @@ const _: () = {
         [::std::mem::offset_of!(QUIC_PATH_STATUS, PathId) - 0usize];
     ["Offset of field: QUIC_PATH_STATUS::Active"]
         [::std::mem::offset_of!(QUIC_PATH_STATUS, Active) - 4usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct QUIC_PATH_STATISTICS {
+    pub PathId: u32,
+    pub Rtt: u64,
+    pub MinRtt: u64,
+    pub MaxRtt: u64,
+    pub Mtu: u16,
+    pub NetworkStatistics: QUIC_NETWORK_STATISTICS,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of QUIC_PATH_STATISTICS"][::std::mem::size_of::<QUIC_PATH_STATISTICS>() - 88usize];
+    ["Alignment of QUIC_PATH_STATISTICS"][::std::mem::align_of::<QUIC_PATH_STATISTICS>() - 8usize];
+    ["Offset of field: QUIC_PATH_STATISTICS::PathId"]
+        [::std::mem::offset_of!(QUIC_PATH_STATISTICS, PathId) - 0usize];
+    ["Offset of field: QUIC_PATH_STATISTICS::Rtt"]
+        [::std::mem::offset_of!(QUIC_PATH_STATISTICS, Rtt) - 8usize];
+    ["Offset of field: QUIC_PATH_STATISTICS::MinRtt"]
+        [::std::mem::offset_of!(QUIC_PATH_STATISTICS, MinRtt) - 16usize];
+    ["Offset of field: QUIC_PATH_STATISTICS::MaxRtt"]
+        [::std::mem::offset_of!(QUIC_PATH_STATISTICS, MaxRtt) - 24usize];
+    ["Offset of field: QUIC_PATH_STATISTICS::Mtu"]
+        [::std::mem::offset_of!(QUIC_PATH_STATISTICS, Mtu) - 32usize];
+    ["Offset of field: QUIC_PATH_STATISTICS::NetworkStatistics"]
+        [::std::mem::offset_of!(QUIC_PATH_STATISTICS, NetworkStatistics) - 40usize];
 };
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/test/MsQuicTests.h
+++ b/src/test/MsQuicTests.h
@@ -688,6 +688,11 @@ QuicTestPathKeepAlive(
     );
 
 void
+QuicTestPathStatistics(
+    _In_ const FamilyArgs& Params
+    );
+
+void
 QuicTestNatPortRebind(
     _In_ int Family,
     _In_ uint16_t KeepAlivePaddingSize

--- a/src/test/bin/quic_gtest.cpp
+++ b/src/test/bin/quic_gtest.cpp
@@ -967,6 +967,15 @@ TEST_P(WithFamilyArgs, PathKeepAlive) {
         QuicTestPathKeepAlive(GetParam());
     }
 }
+
+TEST_P(WithFamilyArgs, PathStatistics) {
+    TestLoggerT<ParamType> Logger("QuicTestPathStatistics", GetParam());
+    if (TestingKernelMode) {
+        ASSERT_TRUE(InvokeKernelTest(FUNC(QuicTestPathStatistics), GetParam()));
+    } else {
+        QuicTestPathStatistics(GetParam());
+    }
+}
 #endif // QUIC_API_ENABLE_PREVIEW_FEATURES
 
 TEST(Mtu, Settings) {

--- a/src/test/bin/winkernel/control.cpp
+++ b/src/test/bin/winkernel/control.cpp
@@ -604,6 +604,7 @@ ExecuteTestRequest(
     RegisterTestFunction(QuicTestServerMigration);
     RegisterTestFunction(QuicTestMultipath);
     RegisterTestFunction(QuicTestPathKeepAlive);
+    RegisterTestFunction(QuicTestPathStatistics);
 #endif // QUIC_API_ENABLE_PREVIEW_FEATURES
 #endif // QUIC_TEST_DATAPATH_HOOKS_ENABLED
     RegisterTestFunction(QuicTestChangeMaxStreamID);

--- a/src/test/lib/PathTest.cpp
+++ b/src/test/lib/PathTest.cpp
@@ -1457,4 +1457,132 @@ QuicTestPathKeepAlive(
     TEST_TRUE(SecondPathCounter.Count >= Expected);
 }
 
+void
+QuicTestPathStatistics(
+    _In_ const FamilyArgs& Params
+    )
+{
+    const int Family = Params.Family;
+
+    PathTestContext Context;
+    PathTestClientContext ClientContext;
+    MsQuicRegistration Registration(true);
+    TEST_TRUE(Registration.IsValid());
+
+    MsQuicConfiguration ServerConfiguration(Registration,
+        "MsQuicTest",
+        MsQuicSettings{}.SetMultipathEnabled(TRUE),
+        ServerSelfSignedCredConfig);
+    TEST_TRUE(ServerConfiguration.IsValid());
+
+    MsQuicCredentialConfig ClientCredConfig;
+    MsQuicConfiguration ClientConfiguration(Registration,
+        "MsQuicTest",
+        MsQuicSettings{}.SetMultipathEnabled(TRUE),
+        ClientCredConfig);
+    TEST_TRUE(ClientConfiguration.IsValid());
+
+    MsQuicAutoAcceptListener Listener(Registration, ServerConfiguration, PathTestContext::ConnCallback, &Context);
+    TEST_QUIC_SUCCEEDED(Listener.GetInitStatus());
+    QUIC_ADDRESS_FAMILY QuicAddrFamily = (Family == 4) ? QUIC_ADDRESS_FAMILY_INET : QUIC_ADDRESS_FAMILY_INET6;
+    QuicAddr ServerLocalAddr(QuicAddrFamily);
+    TEST_QUIC_SUCCEEDED(Listener.Start("MsQuicTest", &ServerLocalAddr.SockAddr));
+    TEST_QUIC_SUCCEEDED(Listener.GetLocalAddr(ServerLocalAddr));
+
+    MsQuicConnection Connection(Registration, MsQuicCleanUpMode::CleanUpManual, PathTestClientContext::ClientCallback, &ClientContext);
+    TEST_QUIC_SUCCEEDED(Connection.GetInitStatus());
+
+    Connection.SetShareUdpBinding();
+
+    TEST_QUIC_SUCCEEDED(Connection.Start(ClientConfiguration, ServerLocalAddr.GetFamily(), QUIC_TEST_LOOPBACK_FOR_AF(ServerLocalAddr.GetFamily()), ServerLocalAddr.GetPort()));
+    TEST_TRUE(Connection.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
+    TEST_TRUE(Context.HandshakeCompleteEvent.WaitTimeout(TestWaitTimeout));
+    TEST_NOT_EQUAL(nullptr, Context.Connection);
+
+    //
+    // One path so far, so a buffer sized for one is exactly what is asked for.
+    //
+    uint32_t Size = 0;
+    TEST_EQUAL(
+        QUIC_STATUS_BUFFER_TOO_SMALL,
+        Connection.GetParam(QUIC_PARAM_CONN_PATH_STATISTICS, &Size, nullptr));
+    TEST_EQUAL(sizeof(QUIC_PATH_STATISTICS), Size);
+
+    QUIC_PATH_STATISTICS OnePath[QUIC_MAX_PATH_COUNT];
+    Size = sizeof(OnePath);
+    TEST_QUIC_SUCCEEDED(
+        Connection.GetParam(QUIC_PARAM_CONN_PATH_STATISTICS, &Size, OnePath));
+    TEST_EQUAL(sizeof(QUIC_PATH_STATISTICS), Size);
+    TEST_TRUE(OnePath[0].Mtu > 0);
+
+    //
+    // Bring up a second path, then expect the array to grow by exactly one.
+    //
+    QuicAddr FirstLocalAddr, SecondLocalAddr, PairAddr;
+    TEST_QUIC_SUCCEEDED(Connection.GetLocalAddr(FirstLocalAddr));
+    TEST_QUIC_SUCCEEDED(Connection.GetLocalAddr(SecondLocalAddr));
+    TEST_QUIC_SUCCEEDED(Connection.GetRemoteAddr(PairAddr));
+    SecondLocalAddr.SetEphemeralPort();
+
+    PathProbeHelper* ProbeHelper = new(std::nothrow) PathProbeHelper(SecondLocalAddr.GetPort());
+    TEST_NOT_EQUAL(nullptr, ProbeHelper);
+
+    QUIC_STATUS Status = QUIC_STATUS_SUCCESS;
+    QUIC_PATH_PARAM PathParam = { &SecondLocalAddr.SockAddr, &PairAddr.SockAddr };
+    int Try = 0;
+    do {
+        Status = Connection.SetParam(QUIC_PARAM_CONN_ADD_PATH, sizeof(PathParam), &PathParam);
+        if (QUIC_FAILED(Status)) {
+            delete ProbeHelper;
+            SecondLocalAddr.SetEphemeralPort();
+            ProbeHelper = new(std::nothrow) PathProbeHelper(SecondLocalAddr.GetPort());
+        }
+    } while (QUIC_FAILED(Status) && ++Try <= 3);
+    TEST_QUIC_SUCCEEDED(Status);
+
+    TEST_TRUE(ProbeHelper->ServerReceiveProbeEvent.WaitTimeout(TestWaitTimeout));
+    TEST_TRUE(ProbeHelper->ClientReceiveProbeEvent.WaitTimeout(TestWaitTimeout));
+    delete ProbeHelper;
+
+    TEST_TRUE(Context.PathAddedEvent.WaitTimeout(TestWaitTimeout));
+    TEST_TRUE(ClientContext.PathAddedEvent.WaitTimeout(TestWaitTimeout));
+
+    QUIC_PATH_STATISTICS PathStats[QUIC_MAX_PATH_COUNT];
+    Size = sizeof(PathStats);
+    TEST_QUIC_SUCCEEDED(
+        Connection.GetParam(QUIC_PARAM_CONN_PATH_STATISTICS, &Size, PathStats));
+    TEST_EQUAL(2 * sizeof(QUIC_PATH_STATISTICS), Size);
+
+    //
+    // Every path reports itself, not a copy of the first one: distinct path IDs,
+    // and an MTU that was actually filled in.
+    //
+    TEST_NOT_EQUAL(PathStats[0].PathId, PathStats[1].PathId);
+    for (uint32_t i = 0; i < 2; ++i) {
+        TEST_TRUE(PathStats[i].Mtu > 0);
+        TEST_TRUE(PathStats[i].Rtt > 0);
+        //
+        // Both are zero on a path with no RTT sample yet; the sentinel MinRtt
+        // carries internally must not reach the caller.
+        //
+        TEST_TRUE(PathStats[i].MinRtt <= PathStats[i].MaxRtt);
+        TEST_TRUE(PathStats[i].NetworkStatistics.CongestionWindow > 0);
+        //
+        // The network statistics are read out of the path's own congestion
+        // control, so this has to agree with the path's RTT above rather than
+        // with whichever path came first.
+        //
+        TEST_EQUAL(PathStats[i].Rtt, PathStats[i].NetworkStatistics.SmoothedRTT);
+    }
+
+    //
+    // A buffer one entry short is refused, and says how much is needed.
+    //
+    Size = sizeof(QUIC_PATH_STATISTICS);
+    TEST_EQUAL(
+        QUIC_STATUS_BUFFER_TOO_SMALL,
+        Connection.GetParam(QUIC_PARAM_CONN_PATH_STATISTICS, &Size, PathStats));
+    TEST_EQUAL(2 * sizeof(QUIC_PATH_STATISTICS), Size);
+}
+
 #endif


### PR DESCRIPTION
## Description

`QUIC_PARAM_CONN_NETWORK_STATISTICS` only ever reports the first path:

```c
Connection->Paths[0].PathID->CongestionControl.QuicCongestionControlGetNetworkStatistics(
    Connection, &Connection->Paths[0].PathID->CongestionControl, Stats);
```

On a multipath connection that leaves the other paths unobservable. `QUIC_PARAM_CONN_PATH_STATISTICS` returns one entry per path instead.

```c
typedef struct QUIC_PATH_STATISTICS {
    uint32_t PathId;
    uint64_t Rtt;                        // Smoothed RTT, microseconds
    uint64_t MinRtt;                     // Zero until the path has an RTT sample
    uint64_t MaxRtt;                     // Zero until the path has an RTT sample
    uint16_t Mtu;
    QUIC_NETWORK_STATISTICS NetworkStatistics;
} QUIC_PATH_STATISTICS;

#define QUIC_PARAM_CONN_PATH_STATISTICS  0x05000026  // QUIC_PATH_STATISTICS[]
```

The path count is not known ahead of time and changes over the connection's life, so it is retrieved the usual two-step way: a `BufferLength` of `0` reports the size needed, and on success `BufferLength` is the number of bytes written, giving the entry count. Paths with no path ID assigned yet — added before the handshake is confirmed — are not reported, having nothing to identify them by and no congestion control to read. Works with or without multipath negotiated; a single-path connection returns one entry.

### Two things beyond the field list

**`PathId` is included.** Array position is not stable — removing a path moves the ones behind it up — so without an identifier the caller cannot tell which entry belongs to which path across calls. It matches the `PathId` used by `QUIC_PARAM_CONN_PATH_STATUS`.

It is not unique, however. `QuicConnGetPathForPacket` assigns a path ID to a rebound path without clearing it from the path being replaced, so during a rebind two entries carry the same `PathId`. Both are real paths, and sharing a path ID means sharing its congestion control, so their `NetworkStatistics` agreeing is correct rather than a defect; the per-path `Rtt`, `MinRtt`, `MaxRtt` and `Mtu` are what tell them apart. Documented rather than filtered — suppressing one would hide a path that exists from an API whose purpose is to report all of them.

**`MinRtt` / `MaxRtt` are normalised.** `QuicPathInitialize` sets `MinRtt = UINT32_MAX` as its "no sample yet" sentinel and leaves `MaxRtt` at zero. Passing that through would report a minimum RTT of roughly 4295 seconds, so a path with nothing measured reports zero for both. `Rtt` needs no such treatment: it starts from the configured `InitialRttMs`.

This differs from `QUIC_STATISTICS_V2`, which passes the sentinel through as-is.

### The network statistics hook now takes a path

Both implementations read the RTT off `Connection->Paths[0]`:

```c
const QUIC_PATH* Path = &Connection->Paths[0];
```

Congestion control is per path ID, so every path would have reported path 0's RTT — and, in cubic, path 0's bandwidth, which is derived from it.

Deriving the path from the congestion control's owning path ID does not work, because that back reference is not always current. `QuicPathSetActive`'s non-multipath branch swaps the *contents* of the two slots:

```c
QUIC_PATH PrevActivePath = Connection->Paths[0];
Connection->Paths[0] = *Path;
*Path = PrevActivePath;
```

The `PathID` pointer travels with the contents while the path ID's back reference stays behind, and `QuicPathRemove` only repairs back references under `if (MultipathNegotiated)`. After a migration without multipath the back reference points at the slot the old path was moved into — and, once that path is removed, at a slot past `PathsCount` holding stale data.

So the path is a parameter of the hook instead, and no caller depends on the back reference:

- `QuicConnGetNetworkStatistics` and the BBR connection event pass `&Connection->Paths[0]`, the expression the hook used internally before, so both keep their behaviour exactly.
- `QuicConnGetPathStatistics` passes the path it is reporting on, which also rules out an entry's `Rtt` disagreeing with its own `NetworkStatistics.SmoothedRTT`.

`BbrTest.cpp` and `CubicTest.cpp` are updated for the signature.

## Testing

New `Basic/WithFamilyArgs.PathStatistics`, registered in `MsQuicTests.h`, `quic_gtest.cpp` and `winkernel/control.cpp`. It queries a one-path connection, brings up a second path, and checks the array grows by exactly one entry; that both entries carry distinct path IDs, a non-zero MTU and RTT, and a `MinRtt` no greater than `MaxRtt`; that a buffer one entry short is refused with the required size; and that each entry's `Rtt` equals its own `NetworkStatistics.SmoothedRTT`.

That last assertion is what pins the per-path plumbing. Instrumented, the two paths report genuinely different figures:

```
path[0] id=0 rtt=2168   min=2168 max=2168 mtu=1280 cwnd=12000 nsRtt=2168   bw=5 inflight=0
path[1] id=1 rtt=333000 min=0    max=0    mtu=1248 cwnd=12200 nsRtt=333000 bw=0 inflight=2440
```

Pointing `QuicConnGetPathStatistics` back at `Paths[0]` turns `path[1]`'s `nsRtt` into path 0's and fails the test.

| Sweep | Result |
|---|---|
| `PathStatistics` × 3 repeats | 6/6 pass |
| `*Multipath*:*Path*:*Migration*:*UnconnectedSocket*:*KeepAlive*:*Statistics*` | 112 tests pass |
| `*Basic*:*Datagram*:*Receive*:*Recv*` | 626 tests pass |
| `msquiccoretest *Bbr*:*Cubic*` | 128 tests pass |
| `cargo test --features preview-api` | 13 pass |

Build is clean. `connection.c`, `cubic.c` and `bbr.c` were run through the CI's clang-tidy 21 in `ghcr.io/microsoft/msquic/linux-build-xcomp:ubuntu-26.04-cross`, since the local one is too old to reproduce what `-CodeCheck` sees.

**Not covered by a test:** the non-multipath migration case above. It is the reason the hook signature changed, but reaching it needs a connection to migrate and then have the old path removed, which the existing path tests do not set up. The two connection-level callers pass the same expression the hook used before, so the change is behaviour-preserving there by construction rather than by test.

## Documentation

`docs/Settings.md` gains the table row and a section covering the two-step sizing, what `PathId` is for and why it is not unique, the zero-until-sampled RTTs, and the fact that paths without a path ID yet are not reported.

The parameter table had a blank line in the middle, which terminated it early and left the last rows rendering as literal `| ... |` text. Removed, which also repairs the `QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET` row that had been broken since it was added.

Rust bindings are regenerated; `win_bindings.rs` cannot be regenerated on Linux, so the identical hunk was applied by hand and diffed against the Linux one. The C# bindings are unchanged, as with previous fork settings.
