### PR TITLE
Document QUIC_PARAM_CONN_PATH_STATUS

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -219,11 +219,35 @@ These parameters are accessed by calling [GetParam](./api/GetParam.md) or [SetPa
 | `QUIC_PARAM_CONN_REMOVE_BOUND_ADDRESS` <br> 29    | QUIC_ADDR                     | Set-only  | Remove a bound address. Server only. |
 | `QUIC_PARAM_CONN_ADD_PATH` <br> 30                | QUIC_PATH_PARAM               | Set-only  | Add a path. Client only. |
 | `QUIC_PARAM_CONN_ACTIVATE_PATH` <br> 31           | QUIC_PATH_PARAM               | Set-only  | Activate a path. Client only. |
-| `QUIC_PARAM_CONN_REMOVE_PATH` <br> 32             | QUIC_PATH_PARAM               | Set-only  | Remove a path. Client only. |
-| `QUIC_PARAM_CONN_ADD_CANDIDATE_ADDRESS` <br> 33   | QUIC_CANDIDATE_ADDRESS        | Set-only  | Add a candidate address. Client only. |
-| `QUIC_PARAM_CONN_REMOVE_CANDIDATE_ADDRESS` <br> 34| QUIC_CANDIDATE_ADDRESS        | Set-only  | Remove a candidate address. Client only. |
+| `QUIC_PARAM_CONN_REMOVE_PATH` <br> 33             | QUIC_PATH_PARAM               | Set-only  | Remove a path. Client only. |
+| `QUIC_PARAM_CONN_ADD_CANDIDATE_ADDRESS` <br> 34   | QUIC_CANDIDATE_ADDRESS        | Set-only  | Add a candidate address. Client only. |
+| `QUIC_PARAM_CONN_REMOVE_CANDIDATE_ADDRESS` <br> 35| QUIC_CANDIDATE_ADDRESS        | Set-only  | Remove a candidate address. Client only. |
+| `QUIC_PARAM_CONN_PATH_STATUS` <br> 36 | QUIC_PATH_STATUS | Set-only | Mark a path active or backup, and tell the peer. Multipath only. See [QUIC_PARAM_CONN_PATH_STATUS](#quic_param_conn_path_status). |
 | `QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET` <br> 37 | uint8_t (BOOLEAN) | Both | Set on client only. Must be set before start, and requires `QUIC_PARAM_CONN_SHARE_UDP_BINDING`. See [QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET](#quic_param_conn_unconnected_udp_socket). |
 | `QUIC_PARAM_CONN_PATH_STATISTICS` <br> 38 | QUIC_PATH_STATISTICS[] | Get-only | Network statistics for every path at once, one array entry per path. See [QUIC_PARAM_CONN_PATH_STATISTICS](#quic_param_conn_path_statistics). |
+
+### QUIC_PARAM_CONN_PATH_STATUS
+
+Marks one path as active or as backup, and announces the change to the peer. Set-only; there is no way to read the current status back through this parameter.
+
+```c
+typedef struct QUIC_PATH_STATUS {
+    uint32_t PathId;
+    BOOLEAN Active;
+} QUIC_PATH_STATUS;
+```
+
+`PathId` selects the path, matching the identifier reported by `QUIC_PARAM_CONN_PATH_STATISTICS` and by the `QUIC_CONNECTION_EVENT_PATH_ADDED` / `PATH_REMOVED` / `PATH_STATUS_CHANGED` events. A path that exists but has not been assigned a path ID yet — one added before the handshake is confirmed — cannot be addressed, and neither can an unknown id; both fail with `QUIC_STATUS_INVALID_PARAMETER`.
+
+The parameter requires multipath to have been negotiated and fails with `QUIC_STATUS_INVALID_STATE` otherwise. `BufferLength` must be exactly `sizeof(QUIC_PATH_STATUS)`.
+
+Setting it has two effects.
+
+Locally, only paths marked active are candidates for sending: when multipath is negotiated and the handshake is confirmed, each packet goes out on a path chosen at random from those that are active and not closing. Marking a path backup therefore takes it out of the rotation while leaving it validated and available.
+
+On the wire, the change is announced with a PATH_AVAILABLE or PATH_BACKUP frame — the PATH_STATUS frames of draft-ietf-quic-multipath — carrying the path ID and a sequence number kept per path ID. Setting the status to the value it already has changes nothing and sends nothing.
+
+The peer can do the same to us. An incoming PATH_AVAILABLE or PATH_BACKUP flips the path's status locally and raises `QUIC_CONNECTION_EVENT_PATH_STATUS_CHANGED` with the new `IsActive`; frames whose sequence number is older than the last one accepted for that path ID are ignored, so reordered announcements cannot undo a newer one. An application that wants to know the current status of a path should follow that event rather than track only what it set itself.
 
 ### QUIC_PARAM_CONN_PATH_STATISTICS
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -230,6 +230,8 @@ These parameters are accessed by calling [GetParam](./api/GetParam.md) or [SetPa
 
 Marks one path as active or as backup, and announces the change to the peer. Set-only; there is no way to read the current status back through this parameter.
 
+The parameter and its struct are behind `QUIC_API_ENABLE_PREVIEW_FEATURES`, which the application must define to use either.
+
 ```c
 typedef struct QUIC_PATH_STATUS {
     uint32_t PathId;
@@ -243,11 +245,15 @@ The parameter requires multipath to have been negotiated and fails with `QUIC_ST
 
 Setting it has two effects.
 
-Locally, only paths marked active are candidates for sending: when multipath is negotiated and the handshake is confirmed, each packet goes out on a path chosen at random from those that are active and not closing. Marking a path backup therefore takes it out of the rotation while leaving it validated and available.
+Locally, the status steers path selection. Once multipath is negotiated and the handshake is confirmed, each send flush picks one path at random from those that are active and not closing, and builds that flush's packets on it — the choice is per flush, not per packet, and a flush triggered by pacing reuses the path the pacing was set up for rather than choosing again. Marking a path backup therefore takes it out of that rotation while leaving it validated and usable.
+
+Two caveats on that. **If no path is active at all**, selection falls back to the first path and keeps sending on it, so marking every path backup does not stop sending. And the status is **not durable against internal changes**: several paths through the stack promote a path to active on their own — the fallback when the active path is removed, and a new path completing validation — and those do not send a PATH_AVAILABLE frame or raise an event. A path the application marked backup can therefore end up active again, with the peer still believing it is backup.
 
 On the wire, the change is announced with a PATH_AVAILABLE or PATH_BACKUP frame — the PATH_STATUS frames of draft-ietf-quic-multipath — carrying the path ID and a sequence number kept per path ID. Setting the status to the value it already has changes nothing and sends nothing.
 
-The peer can do the same to us. An incoming PATH_AVAILABLE or PATH_BACKUP flips the path's status locally and raises `QUIC_CONNECTION_EVENT_PATH_STATUS_CHANGED` with the new `IsActive`; frames whose sequence number is older than the last one accepted for that path ID are ignored, so reordered announcements cannot undo a newer one. An application that wants to know the current status of a path should follow that event rather than track only what it set itself.
+The peer can do the same to us. An incoming PATH_AVAILABLE or PATH_BACKUP flips the path's status locally and raises `QUIC_CONNECTION_EVENT_PATH_STATUS_CHANGED` with the new `IsActive`. A frame whose sequence number is not greater than the last one accepted for that path ID is ignored, so a reordered announcement cannot undo a newer one.
+
+That event fires only for changes the peer initiated; setting this parameter raises nothing. An application tracking the current status of a path needs both — what it set itself, and what arrives on the event — and, given the promotion caveat above, neither is a complete record.
 
 ### QUIC_PARAM_CONN_PATH_STATISTICS
 


### PR DESCRIPTION
## Description

`QUIC_PARAM_CONN_PATH_STATUS` had no row in the connection parameter table and no section of its own. Its only appearance in `docs/Settings.md` was a passing reference from the `QUIC_PARAM_CONN_PATH_STATISTICS` section, which assumed the reader already knew what it was.

Written from the implementation:

- **Set-only.** It appears in `QuicConnParamSet` and nowhere in `QuicConnParamGet`, so the current status cannot be read back through it. Worth stating, since the name reads like something you could query.
- Requires multipath to have been negotiated (`QUIC_STATUS_INVALID_STATE` otherwise) and an exact `BufferLength`.
- Selects the path by `PathId` against `Paths[i].PathID->ID`, skipping paths that have no path ID yet — one added before the handshake is confirmed. An unknown id is `QUIC_STATUS_INVALID_PARAMETER`.
- Behind `QUIC_API_ENABLE_PREVIEW_FEATURES`, along with the `QUIC_PATH_STATUS` struct.

### What the status actually does

The interesting part, and the part an early draft of this section got wrong in three ways.

**It steers path selection, per flush.** Once multipath is negotiated and the handshake is confirmed, each `QuicSendFlush` picks one path at random from those active and not closing, and builds that flush's packets on it. Not per packet — and a flush triggered by pacing reuses `Send->PacingPath` without choosing at all.

**Marking everything backup does not stop sending.** `QuicConnChoosePath` opens with `QUIC_PATH* Path = &Connection->Paths[0];` and only replaces it inside `if (ActivePathCount > 0)`. With no active path it returns the first one and sending continues there.

**The status is not durable against internal changes.** Under multipath `QuicPathSetActive` is just `Path->IsActive = TRUE;` — no `SendStatus`, no `QUIC_CONN_SEND_FLAG_PATH_AVAILABLE`. It runs from the fallback when the active path is removed (`path.c`) and when a new path finishes validation (`connection.c`), so a path the application marked backup can be promoted again with nothing sent to the peer and no event raised. This is the one most likely to surprise: it is natural to assume a status holds until you change it.

### On the wire, and from the peer

The change is announced with a PATH_AVAILABLE or PATH_BACKUP frame — the PATH_STATUS frames of draft-ietf-quic-multipath — carrying the path ID and a per-path-ID sequence number. Setting the status a path already has sends nothing, since the send flag is raised only when the value changes.

The peer can flip it on us. An incoming frame updates the path and raises `QUIC_CONNECTION_EVENT_PATH_STATUS_CHANGED`; a frame whose sequence number is *not greater than* the last accepted for that path ID is ignored — `StatusRecvSeq` is stored as `lastAccepted + 1` and tested with `<`, so an equal one is dropped as well.

That event fires only for peer-initiated changes; setting the parameter locally raises nothing. So an application tracking a path's status needs both what it set and what arrives on the event — and, given the promotion caveat, neither is a complete record. The section says so rather than leaving the reader to find out.

### Also: three misnumbered rows

The number in that column is the parameter's low byte in decimal — every row follows it. Checking all connection rows against `msquic.h` mechanically turned up three that were one low:

| Row | Value | Was | Now |
|---|---|---|---|
| `QUIC_PARAM_CONN_REMOVE_PATH` | `0x05000021` | 32 | 33 |
| `QUIC_PARAM_CONN_ADD_CANDIDATE_ADDRESS` | `0x05000022` | 33 | 34 |
| `QUIC_PARAM_CONN_REMOVE_CANDIDATE_ADDRESS` | `0x05000023` | 34 | 35 |

They drifted when `QUIC_PARAM_CONN_NETWORK_STATISTICS` (`0x05000020`, so 32) was inserted out of numeric order and the rows after it were numbered sequentially instead of from their values. Fixed because leaving them wrong immediately above a newly added correct row is worse than the small scope increase.

### Left alone

The `(preview)` marker on the table row. All **fifteen** preview-guarded connection parameters are unmarked there — `CIBIR_ID`, `VERSION_SETTINGS`, `NETWORK_STATISTICS`, `CLOSE_ASYNC`, the bound and observed address ones, all four path ones, `UNCONNECTED_UDP_SOCKET`, `PATH_STATISTICS` and this one. Marking a single row would read as if the other fourteen were not preview. The requirement is stated in the section prose instead, which is what protects someone copying the struct; the table is a sweep of its own.

## Testing

Documentation only — no code change, so nothing to run.

Checked mechanically: every `QUIC_PARAM_CONN_*` row matches the value in `msquic.h` (0 mismatches across 39 rows), the table is one unbroken block with no stray blank line, and every `See [...](#anchor)` link resolves to a heading in the file.

## Documentation

This is the documentation.
